### PR TITLE
Markdown rendering cleanup and fix

### DIFF
--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -1,12 +1,12 @@
 """Module for event related classes
 """
-import re
-import markdown
 from flask_uploads import UploadSet, IMAGES
 
 from .globals import db
 from .registration import RegistrationStatus
 from .utils import ChoiceEnum
+
+from ..utils import render_markdown
 
 photos = UploadSet("photos", IMAGES)
 """Upload instance for events photos
@@ -202,12 +202,7 @@ class Event(db.Model):
         :return: Rendered :py:attr:`description` as HTML
         :rtype: string
         """
-        # Urify links
-        # From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
-        # pylint: disable=C0301
-        URI_REGEX = r'(?i)(^|^\s|[^(]\s+|[^\]]\(\s*)((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
-        description = re.sub(URI_REGEX, r"\1[\2](\2)", description)
-        self.rendered_description = markdown.markdown(description, extensions=["nl2br"])
+        self.rendered_description = render_markdown.markdown_to_html(description)
         return self.rendered_description
 
     # Date validation

--- a/collectives/utils/render_markdown.py
+++ b/collectives/utils/render_markdown.py
@@ -3,52 +3,76 @@ import markdown
 from markdown.preprocessors import Preprocessor
 from markdown.extensions import Extension
 
-# Urify links
-# From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
 # pylint: disable=C0301
 URI_REGEX = re.compile(
     r'(?i)(^|^\s|[^(]\s+|[^\]]\(\s*)((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
 )
+"""
+ Regexp for detecting links
+ From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
+"""
 
 BLANK_REGEX = re.compile(r"^\s*$")
+"""
+Regexp for detecting blank lines
+"""
+
 LIST_REGEX = re.compile(r"^\s*([-*+]|[0-9]\.)")
-
-
-class Urify(Preprocessor):
-    def run(self, lines):
-        return [URI_REGEX.sub(r"\1[\2](\2)", line) for line in lines]
+"""
+Regexp for detecting list items
+"""
 
 
 class UrifyExtension(Extension):
+    """
+    A markdown extension that adds link tags around URIs
+    """
+
+    class Impl(Preprocessor):
+        def run(self, lines):
+            return [URI_REGEX.sub(r"\1[\2](\2)", line) for line in lines]
+
     def extendMarkdown(self, md):
-        md.preprocessors.register(Urify(md), "prepend", 10)
-
-
-class PrependBlankLine(Preprocessor):
-    def run(self, lines):
-        result = []
-        was_blank = False
-        was_list = False
-        for line in lines:
-            if LIST_REGEX.match(line):
-                if not (was_blank or was_list):
-                    # Insert a blank line before start of list
-                    result.append("\n")
-
-                was_blank = False
-                was_list = True
-            else:
-                was_list = False
-                was_blank = BLANK_REGEX.match(line)
-            result.append(line)
-        return result
+        md.preprocessors.register(UrifyExtension.Impl(md), "prepend", 10)
 
 
 class PrependBlankLineExtension(Extension):
+    """
+    A markdown extension that ensures there is a blank line before the
+    first item of each list
+    (Otherwise markdown does not interpret it as a proper list)
+    """
+
+    class Impl(Preprocessor):
+        def run(self, lines):
+            result = []
+            was_blank = False
+            was_list = False
+            for line in lines:
+                if LIST_REGEX.match(line):
+                    if not (was_blank or was_list):
+                        # Insert a blank line before start of list
+                        result.append("\n")
+
+                    was_blank = False
+                    was_list = True
+                else:
+                    was_list = False
+                    was_blank = BLANK_REGEX.match(line)
+                result.append(line)
+            return result
+
     def extendMarkdown(self, md):
-        md.preprocessors.register(PrependBlankLine(md), "prepend", 20)
+        md.preprocessors.register(PrependBlankLineExtension.Impl(md), "prepend", 20)
 
 
 def markdown_to_html(text):
+    """Render markdown text to html.
+
+    :param description: Markdown source.
+    :type description: string
+    :return: Rendered text as HTML
+    :rtype: string
+    """
     extensions = ["nl2br", UrifyExtension(), PrependBlankLineExtension()]
     return markdown.markdown(text, extensions=extensions)

--- a/collectives/utils/render_markdown.py
+++ b/collectives/utils/render_markdown.py
@@ -17,7 +17,7 @@ BLANK_REGEX = re.compile(r"^\s*$")
 Regexp for detecting blank lines
 """
 
-LIST_REGEX = re.compile(r"^\s*([-*+]|[0-9]\.)")
+LIST_REGEX = re.compile(r"^\s*([-*+]|[0-9]\.)\s")
 """
 Regexp for detecting list items
 """

--- a/collectives/utils/render_markdown.py
+++ b/collectives/utils/render_markdown.py
@@ -1,0 +1,54 @@
+import re
+import markdown
+from markdown.preprocessors import Preprocessor
+from markdown.extensions import Extension
+
+# Urify links
+# From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
+# pylint: disable=C0301
+URI_REGEX = re.compile(
+    r'(?i)(^|^\s|[^(]\s+|[^\]]\(\s*)((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
+)
+
+BLANK_REGEX = re.compile(r"^\s*$")
+LIST_REGEX = re.compile(r"^\s*([-*+]|[0-9]\.)")
+
+
+class Urify(Preprocessor):
+    def run(self, lines):
+        return [URI_REGEX.sub(r"\1[\2](\2)", line) for line in lines]
+
+
+class UrifyExtension(Extension):
+    def extendMarkdown(self, md):
+        md.preprocessors.register(Urify(md), "prepend", 10)
+
+
+class PrependBlankLine(Preprocessor):
+    def run(self, lines):
+        result = []
+        was_blank = False
+        was_list = False
+        for line in lines:
+            if LIST_REGEX.match(line):
+                if not (was_blank or was_list):
+                    # Insert a blank line before start of list
+                    result.append("\n")
+
+                was_blank = False
+                was_list = True
+            else:
+                was_list = False
+                was_blank = BLANK_REGEX.match(line)
+            result.append(line)
+        return result
+
+
+class PrependBlankLineExtension(Extension):
+    def extendMarkdown(self, md):
+        md.preprocessors.register(PrependBlankLine(md), "prepend", 20)
+
+
+def markdown_to_html(text):
+    extensions = ["nl2br", UrifyExtension(), PrependBlankLineExtension()]
+    return markdown.markdown(text, extensions=extensions)

--- a/collectives/utils/render_markdown.py
+++ b/collectives/utils/render_markdown.py
@@ -17,7 +17,7 @@ BLANK_REGEX = re.compile(r"^\s*$")
 Regexp for detecting blank lines
 """
 
-LIST_REGEX = re.compile(r"^\s*([-*+]|[0-9]\.)\s")
+LIST_REGEX = re.compile(r"^\s*([-*+]|[0-9]+\.)\s")
 """
 Regexp for detecting list items
 """
@@ -33,7 +33,7 @@ class UrifyExtension(Extension):
             return [URI_REGEX.sub(r"\1[\2](\2)", line) for line in lines]
 
     def extendMarkdown(self, md):
-        md.preprocessors.register(UrifyExtension.Impl(md), "prepend", 10)
+        md.preprocessors.register(UrifyExtension.Impl(md), "urify", 10)
 
 
 class PrependBlankLineExtension(Extension):

--- a/doc/source/utils.rst
+++ b/doc/source/utils.rst
@@ -16,6 +16,12 @@ Module ``collectives.utils.extranet``
 .. automodule:: collectives.utils.extranet
     :members:
 
+Module ``collectives.utils.render_markdown``
+----------------------------------------------
+.. automodule:: collectives.utils.render_markdown
+    :members:
+
+
 Module ``collectives.utils.mail``
 ---------------------------------
 .. automodule:: collectives.utils.mail


### PR DESCRIPTION
 - Extract markdown rendering from `model.event` to `utils.render_markdown`
 - Fix unintuitive markdown behaviour: Standard markdown requires a blank line before the start of  each list, but Github-flavoured markdown does not, nor does SimpleMDE editor preview. This can be confusing for users. To fix that add a blank line before the first item of each list.

For instance, this will fix the "Required gear" list in https://test.collectives.cafannecy.fr/event/17