### PR TITLE
More explicit message for maximum authorized image size

### DIFF
--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -105,7 +105,7 @@
     <div id="editor">
     {{ form.description }}
     </div>
-    <label for="photo_file">Image de présentation : <br/>&#9432; Max 2MB. Photo uniquement </label> {{ form.photo_file }} <br/>
+    <label for="photo_file">Image de présentation : <br/>&#9432; Photo uniquement, d'une taille maximum de 2Mo</label> {{ form.photo_file }} <br/>
     <br/>
     {{ form.hidden_tag() }}
      <br/>{{ form.save_all }}


### PR DESCRIPTION
For old people who don't take time to read warnings, display a more explicit message for maximum authorized image size