### PR TITLE
Single activity workflow

### DIFF
--- a/collectives/forms/event.py
+++ b/collectives/forms/event.py
@@ -16,7 +16,7 @@ from ..models import ActivityType
 from ..models import User, Role, RoleIds, db
 
 
-def available_leaders(leaders):
+def available_leaders(leaders, activity_ids):
     """Creates a list of leaders that can be added to an event.
 
     This list can be used in a select form input. It will all users with
@@ -32,14 +32,16 @@ def available_leaders(leaders):
 
     query = db.session.query(User)
     query = query.filter(Role.user_id == User.id)
-    query = query.filter(Role.role_id.in_(RoleIds.all_event_creator_roles()))
+    query = query.filter(Role.role_id.in_(RoleIds.all_activity_leader_roles()))
+    if len(activity_ids) > 0:
+        query = query.filter(Role.activity_id.in_(activity_ids))
     query = query.order_by(User.first_name, User.last_name)
     choices = query.all()
 
     return [u for u in choices if u not in existing_leaders]
 
 
-def available_activities(activities, leaders):
+def available_activities(activities, leaders, union):
     """Creates a list of activities theses leaders can lead.
 
     This list can be used in a select form input. It will contain activities
@@ -49,8 +51,10 @@ def available_activities(activities, leaders):
 
     :param activities: list of activities that will always appears in the list
     :type activities: list[:py:class:`collectives.models.activitytype.ActivityType`]
-    :param leader: list of leader used to build activity list.
-    :type leader: list[:py:class:`collectives.models.user.User`]
+    :param leaders: list of leader used to build activity list.
+    :type leaders: list[:py:class:`collectives.models.user.User`]
+    :param union: If true, return the union all activities that can be lead, otherwise return the intersection
+    :type union: bool
     :return: List of authorized activities
     :rtype: list[:py:class:`collectives.models.activitytype.ActivityType`]
     """
@@ -60,8 +64,12 @@ def available_activities(activities, leaders):
         # Gather unique activities
         choices = set(activities)
         for leader in leaders:
-            choices.update(leader.led_activities())
+            if union:
+                choices |= leader.led_activities()
+            else:
+                choices &= leader.led_activities()
         choices = list(choices)
+
     choices.sort(key=attrgetter("order", "name", "id"))
 
     return choices
@@ -110,13 +118,16 @@ class EventForm(ModelForm, FlaskForm):
 
     main_leader_id = RadioField("Responsable", coerce=int)
 
+    update_activity = HiddenField()
     update_leaders = SubmitField("Mettre à jour les encadrants")
     save_all = SubmitField("Enregistrer")
 
     current_leaders = []
     main_leader_fields = []
 
-    def __init__(self, event, *args, **kwargs):
+    multi_activities_mode = False
+
+    def __init__(self, event, multi_activities_mode, *args, **kwargs):
         """
         event is only used to populate activity/leader field choices.
         It is different from passing obj=event, which would populate all form fields
@@ -124,12 +135,12 @@ class EventForm(ModelForm, FlaskForm):
         """
         super(EventForm, self).__init__(*args, **kwargs)
 
-        if event is not None:
-            self.set_current_leaders(event.leaders)
-            self.update_choices(event)
-
         if "obj" in kwargs:
             self.type.data = int(kwargs["obj"].activity_types[0].id)
+
+        self.multi_activities_mode = multi_activities_mode
+        self.set_current_leaders(event.leaders)
+        self.update_choices(event)
 
     def set_current_leaders(self, leaders):
         """
@@ -148,12 +159,15 @@ class EventForm(ModelForm, FlaskForm):
         :param event: Event being currently edited
         :type event: :py:class:`collectives.modes.event.Event`
         """
-        leader_choices = available_leaders(self.current_leaders)
+        activity_ids = (
+            [] if self.multi_activities_mode or not self.type.data else [self.type.data]
+        )
+        leader_choices = available_leaders(self.current_leaders, activity_ids)
         self.add_leader.choices = [(0, "")]
         self.add_leader.choices += [(u.id, u.full_name()) for u in leader_choices]
 
         activity_choices = available_activities(
-            event.activity_types, self.current_leaders
+            event.activity_types, self.current_leaders, self.multi_activities_mode
         )
         self.type.choices = [(a.id, a.name) for a in activity_choices]
 
@@ -190,3 +204,7 @@ class EventForm(ModelForm, FlaskForm):
 
         # Remove placeholders
         self.description.data = description.format(**columns)
+
+    def current_activities(self):
+        activity = ActivityType.query.get(self.type.data)
+        return [] if activity is None else [activity]

--- a/collectives/forms/event.py
+++ b/collectives/forms/event.py
@@ -70,7 +70,7 @@ def available_activities(activities, leaders, union):
         for leader in leaders:
             if choices is None:
                 choices = leader.led_activities()
-            if union:
+            elif union:
                 choices |= leader.led_activities()
             else:
                 choices &= leader.led_activities()

--- a/collectives/forms/event.py
+++ b/collectives/forms/event.py
@@ -74,6 +74,7 @@ def available_activities(activities, leaders, union):
                 choices |= leader.led_activities()
             else:
                 choices &= leader.led_activities()
+        # Always include existing activities
         choices = list(choices | set(activities))
 
     choices.sort(key=attrgetter("order", "name", "id"))

--- a/collectives/models/activitytype.py
+++ b/collectives/models/activitytype.py
@@ -93,4 +93,4 @@ def leaders_without_activities(activities, leaders):
     :return: True if leaders can lead all activities.
     :rtype: boolean
     """
-    return [l for l in leaders if not l.can_lead_activity(activities)]
+    return [l for l in leaders if not l.can_lead_activities(activities)]

--- a/collectives/models/activitytype.py
+++ b/collectives/models/activitytype.py
@@ -62,3 +62,35 @@ class ActivityType(db.Model):
         :return: list of types
         :rtype: list(:py:class:`ActivityType`)"""
         return cls.query.order_by("order", "name").all()
+
+
+def activities_without_leader(activities, leaders):
+    """Check if leaders has right to lead it.
+
+    Test each activity to see if at least one leader can lead it (see
+    :py:meth:`collectives.models.actitivitytype.ActivityType.can_be_led_by`
+    ).
+    Return the list of activitiers with no valid leader
+
+    :param leaders: List of User which will be tested.
+    :type leaders: list
+    :return: True if leaders can lead all activities.
+    :rtype: boolean
+    """
+    return [a for a in activities if not a.can_be_led_by(leaders)]
+
+
+def leaders_without_activities(activities, leaders):
+    """Check if leaders has right to lead it.
+
+    Test each leader to see if they can lead each activity
+    :py:meth:`collectives.models.actitivitytype.ActivityType.can_be_led_by`
+    ).
+    Return the list of leaders not able to lead all activities
+
+    :param leaders: List of User which will be tested.
+    :type leaders: list
+    :return: True if leaders can lead all activities.
+    :rtype: boolean
+    """
+    return [l for l in leaders if not l.can_lead_activity(activities)]

--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -5,6 +5,7 @@ from flask_uploads import UploadSet, IMAGES
 from .globals import db
 from .registration import RegistrationStatus
 from .utils import ChoiceEnum
+from .activitytype import activities_without_leader
 
 from ..utils import render_markdown
 
@@ -277,21 +278,6 @@ class Event(db.Model):
         # pylint: disable=C0301
         return self.num_online_slots >= 0 and self.num_slots >= self.num_online_slots
 
-    def activities_without_leader(self, leaders):
-        """Check if leaders has right to lead it.
-
-        Test each activity to see if at least one leader can lead it (see
-        :py:meth:`collectives.models.actitivitytype.ActivityType.can_be_led_by`
-        ).
-        Return the list of activitiers with no valid leader
-
-        :param leaders: List of User which will be tested.
-        :type leaders: list
-        :return: True if leaders can lead all activities.
-        :rtype: boolean
-        """
-        return [a for a in self.activity_types if not a.can_be_led_by(leaders)]
-
     def has_valid_leaders(self):
         """
         :return: True if current leaders can lead all activities. If activities are empty, returns False.
@@ -299,7 +285,7 @@ class Event(db.Model):
         """
         if not any(self.activity_types):
             return False
-        return not any(self.activities_without_leader(self.leaders))
+        return not any(activities_without_leader(self.activity_types, self.leaders))
 
     def ranked_leaders(self):
         """

--- a/collectives/models/user.py
+++ b/collectives/models/user.py
@@ -306,6 +306,9 @@ class User(db.Model, UserMixin):
             RoleIds.all_activity_leader_roles(), activity_id
         )
 
+    def can_lead_activities(self, activities):
+        return all(self.can_lead_activity(a.id) for a in activities)
+
     def can_read_other_users(self):
         return self.has_signed_ca() and self.has_any_role()
 

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -314,7 +314,7 @@ def manage_event(event_id=None):
     # We have changed activity or removed a leader
     # Check that there is a valid leader
     if has_new_activity or has_removed_leaders:
-        if not accept_event_leaders(event, tentative_leaders):
+        if not accept_event_leaders(event, tentative_leaders, multi_activities_mode):
             return render_template(
                 "editevent.html", conf=current_app.config, event=event, form=form
             )

--- a/collectives/static/css/event/edit.css
+++ b/collectives/static/css/event/edit.css
@@ -40,7 +40,19 @@
 #encadrement .useractionmenu{
   display:inline-block;
   text-align: center;
+  position: relative;
   margin-bottom:0.5em;
+}
+
+#encadrement .useractionmenu .delete {
+  color:white;
+  background-color: darkred;
+  padding:5px;
+  font-weight:normal;
+}
+
+#encadrement .useractionmenu .delete:hover {
+  background-color: red;
 }
 
 #eventedit form div.inline_field{

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -41,15 +41,15 @@
         onsubmit="document.querySelector('textarea[name=description]').value=simplemde.value()"
         enctype="multipart/form-data"
   >
+
     {# We want to make sure pressing 'Enter' submits the whole form #}
     {# For this add a hidden submit button before 'update_leaders' #}
     {{form.save_all(id="hidden_save_all", style="visibility:hidden;position:absolute;") }} 
 
-
     <h4>Activité et encadrants</h4>
       {{form.update_activity(value=0)}}
      
-      <label for="type">Activité : </label> {{ form.type(onchange="javascript:document.getElementById('update_activity').value=1; this.form.submit();") }}<br/>
+      <label for="type">Activité : </label> {{ form.type(onchange="javascript:updateActivity(this)") }}<br/>
       <fieldset>
       <legend>Encadrants:</legend>
 
@@ -63,11 +63,16 @@
             <br/>
             <div class="inline_field">
               {{action.leader_id}}  
-              {% if event.can_remove_leader(current_user, user)  %}
-                {{action.delete}}  
-                {{action.delete.label}} <br />
+              {% if form.can_remove_leader(event, user)  %}
+                {# {{action.delete(onchange="javascript:updateLeaders(this);", style="display:block")}} #} 
+                {# <button class="button delete" onlick="javascript:document.getElementById('{{action.delete.id}}').checked = true; removeRequiredFields();" >Supprimer</a> #}
+                {# <button class="button delete"  name="{{action.delete.name}}" onclick="javascript:removeRequiredAttributes();" value="y">Supprimer</button> #}
+                <button class="button delete"  name="{{action.delete.name}}" onclick="javascript:removeRequiredAttributes();" value="y">
+                  <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-trash-white.svg') }}"/>
+                  Supprimer
+                </button>
               {% endif %}
-              {{ form.main_leader_fields[loop.index0] }}
+              {{ form.main_leader_fields[loop.index0](onchange="javascript:updateLeaders(this);") }}
               {{ form.main_leader_fields[loop.index0].label }}
             </div>
           </div>
@@ -76,10 +81,9 @@
       </div>
       <div>
         {{ form.add_leader.label }}
-        {{ form.add_leader(title=form.add_leader.description) }}<br />
+        {{ form.add_leader(title=form.add_leader.description, onchange="javascript:updateLeaders(this);") }}<br />
       </div>
-
-      <br/>{{ form.update_leaders(onclick="removeRequiredAttributes()") }}
+      {{ form.update_leaders(value=0) }}
     </fieldset>
     
     <h4>Informations</h4>
@@ -127,6 +131,17 @@
   </form>
 </div>
 <script>
+function updateActivity(element)
+{
+    document.getElementById('update_activity').value=1; 
+    element.form.submit();
+}
+function updateLeaders(element)
+{
+    document.getElementById('update_leaders').value=1; 
+    element.form.submit();
+}
+
 document.querySelectorAll("input[type=datetime]").forEach(function(input){
                 var datepicker = tail.DateTime(input,{
                     animate: false,

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -46,37 +46,44 @@
     {{form.save_all(id="hidden_save_all", style="visibility:hidden;position:absolute;") }} 
 
 
-    <h4>Encadrants</h4>
-    <div id="encadrement">
-      {% for action in form.leader_actions %}
-        {% with user = form.current_leaders[loop.index0]%}
-        <div class="useractionmenu">
-          {% with leader_info=True %}
-            {{ macros.usericon(user, leader_info, user_info) }}
-          {% endwith %}
-          <br/>
-          <div class="inline_field">
-            {{action.leader_id}}  
-            {% if event.can_remove_leader(current_user, user)  %}
-              {{action.delete}}  
-              {{action.delete.label}} <br />
-            {% endif %}
-            {{ form.main_leader_fields[loop.index0] }}
-            {{ form.main_leader_fields[loop.index0].label }}
+    <h4>Activité et encadrants</h4>
+      {{form.update_activity(value=0)}}
+     
+      <label for="type">Activité : </label> {{ form.type(onchange="javascript:document.getElementById('update_activity').value=1; this.form.submit();") }}<br/>
+      <fieldset>
+      <legend>Encadrants:</legend>
+
+      <div id="encadrement">
+        {% for action in form.leader_actions %}
+          {% with user = form.current_leaders[loop.index0]%}
+          <div class="useractionmenu">
+            {% with leader_info=True %}
+              {{ macros.usericon(user, leader_info, user_info) }}
+            {% endwith %}
+            <br/>
+            <div class="inline_field">
+              {{action.leader_id}}  
+              {% if event.can_remove_leader(current_user, user)  %}
+                {{action.delete}}  
+                {{action.delete.label}} <br />
+              {% endif %}
+              {{ form.main_leader_fields[loop.index0] }}
+              {{ form.main_leader_fields[loop.index0].label }}
+            </div>
           </div>
-        </div>
-        {% endwith %}
-      {% endfor %}
-    </div>
-    <div>
-       {{ form.add_leader.label }}
-       {{ form.add_leader(title=form.add_leader.description) }}<br />
-    </div>
-    <br/>{{ form.update_leaders(onclick="removeRequiredAttributes()") }}
+          {% endwith %}
+        {% endfor %}
+      </div>
+      <div>
+        {{ form.add_leader.label }}
+        {{ form.add_leader(title=form.add_leader.description) }}<br />
+      </div>
+
+      <br/>{{ form.update_leaders(onclick="removeRequiredAttributes()") }}
+    </fieldset>
     
     <h4>Informations</h4>
      <label for="title">Titre : </label> {{ form.title(size=200) }}<br/>
-     <label for="type">Type : </label> {{ form.type }}<br/>
      <label for="status">État : </label> {{ form.status }}<br/>
      <label for="num_slots">Nombre de participants : </label> {{ form.num_slots(size=4) }}<br/>
 

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -64,9 +64,6 @@
             <div class="inline_field">
               {{action.leader_id}}  
               {% if form.can_remove_leader(event, user)  %}
-                {# {{action.delete(onchange="javascript:updateLeaders(this);", style="display:block")}} #} 
-                {# <button class="button delete" onlick="javascript:document.getElementById('{{action.delete.id}}').checked = true; removeRequiredFields();" >Supprimer</a> #}
-                {# <button class="button delete"  name="{{action.delete.name}}" onclick="javascript:removeRequiredAttributes();" value="y">Supprimer</button> #}
                 <button class="button delete"  name="{{action.delete.name}}" onclick="javascript:removeRequiredAttributes();" value="y">
                   <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-trash-white.svg') }}"/>
                   Supprimer


### PR DESCRIPTION
Workflow activité unique, comme discuté dans #173 : n'autorise à ajouter des encadrants que s'il peuvent encadrer l'activité choisies (sauf pour les admin, qui peuvent toujours ajouter n'importe qui).
Également changé le formulaire pour qu'il n'y ait plus besoin de valider l'ajout/suppression d'encadrants, la page est rechargée automatiquement 