### PR TITLE
[FEATURE] Do not display time in event title when set to midnight

### DIFF
--- a/collectives/context_processor.py
+++ b/collectives/context_processor.py
@@ -1,7 +1,7 @@
 """Helpers functions that are make available to Jinja
 """
-from .helpers import current_time
 from datetime import time
+from .helpers import current_time
 
 # Server may not have fr_FR locale installed, for convenience
 # simply define days of weeks and months names here

--- a/collectives/context_processor.py
+++ b/collectives/context_processor.py
@@ -1,6 +1,7 @@
 """Helpers functions that are make available to Jinja
 """
 from .helpers import current_time
+from datetime import time
 
 # Server may not have fr_FR locale installed, for convenience
 # simply define days of weeks and months names here
@@ -62,19 +63,14 @@ def helpers_processor():
 
     def format_datetime_range(start, end):
         if start == end:
-            if (
-                start.hour == 0
-                and start.minute == 0
-                and end.hour == 0
-                and end.minute == 0
-            ):
+            if start.time() == time(0):
                 return "{}".format(format_date(start))
             return "{} à {}".format(format_date(start), format_time(start))
         if start.date() == end.date():
             return "{} de {} à {}".format(
                 format_date(start), format_time(start), format_time(end)
             )
-        if start.hour == 0 and start.minute == 0 and end.hour == 0 and end.minute == 0:
+        if start.time() == time(0) and end.time() == time(0):
             return "du {} au {}".format(format_date(start), format_date(end))
         return "du {} à {} au {} à {}".format(
             format_date(start), format_time(start), format_date(end), format_time(end),

--- a/collectives/context_processor.py
+++ b/collectives/context_processor.py
@@ -49,7 +49,7 @@ def helpers_processor():
     def format_date_short(datetime):
         if datetime is None:
             return "N/A"
-        return "{}. {} {}.".format(
+        return "{}. {} {}".format(
             fr_week_days[datetime.weekday()][0:3],
             datetime.day,
             fr_short_months[datetime.month - 1],
@@ -58,15 +58,26 @@ def helpers_processor():
     def format_time(datetime):
         if datetime is None:
             return "N/A"
-        return u"{h}\xa0h\xa0{m:02d}".format(h=datetime.hour, m=datetime.minute)
+        return u"{h}h{m:02d}".format(h=datetime.hour, m=datetime.minute)
 
     def format_datetime_range(start, end):
         if start == end:
+            if (
+                start.hour == 0
+                and start.minute == 0
+                and end.hour == 0
+                and end.minute == 0
+            ):
+                return "{}".format(format_date(start))
             return "{} à {}".format(format_date(start), format_time(start))
         if start.date() == end.date():
             return "{} de {} à {}".format(
                 format_date(start), format_time(start), format_time(end)
             )
+        elif (
+            start.hour == 0 and start.minute == 0 and end.hour == 0 and end.minute == 0
+        ):
+            return "du {} au {}".format(format_date(start), format_date(end))
         return "du {} à {} au {} à {}".format(
             format_date(start), format_time(start), format_date(end), format_time(end)
         )

--- a/collectives/context_processor.py
+++ b/collectives/context_processor.py
@@ -74,12 +74,10 @@ def helpers_processor():
             return "{} de {} à {}".format(
                 format_date(start), format_time(start), format_time(end)
             )
-        elif (
-            start.hour == 0 and start.minute == 0 and end.hour == 0 and end.minute == 0
-        ):
+        if start.hour == 0 and start.minute == 0 and end.hour == 0 and end.minute == 0:
             return "du {} au {}".format(format_date(start), format_date(end))
         return "du {} à {} au {} à {}".format(
-            format_date(start), format_time(start), format_date(end), format_time(end)
+            format_date(start), format_time(start), format_date(end), format_time(end),
         )
 
     def format_date_range(start, end):

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -26,25 +26,28 @@ window.onload = function(){
                 // If eventsTable is not ready to be used: exit
                 if(eventsTable == undefined)
                     return 0;
-                if(sorters[0]['field'] != 'title')
-                    eventsTable.setGroupBy(sorters[0]['field']);
-                else
+                if(sorters[0]['field'] == 'title')
                     eventsTable.setGroupBy(false);
+                else if (sorters[0]['field'] == 'start')
+                    eventsTable.setGroupBy(function(data){
+                        return moment(data.start).format('dddd D MMMM YYYY').capitalize();
+                    });
+                else
+                    eventsTable.setGroupBy(sorters[0]['field']);
             },
-
             pagination : 'remote',
             paginationSize : 10,
             pageLoaded :  updatePageURL,
 
             initialSort: [ {column:"start", dir:"asc"}],
-            initialFilter: [{field:"end", type:">=", value:"now" }], 
+            initialFilter: [{field:"end", type:">=", value:"now" }],
   			columns:[
       			{title:"Titre", field:"title", sorter:"string"},
                 {title:"Date", field:"start", sorter:"string"},
   			],
   			    rowFormatter: eventRowFormatter,
             groupHeader:function(value, count, data, group){
-                return moment(value).format('dddd D MMMM YYYY').capitalize();
+                return value;
             },
             locale: true,
             locale:true,
@@ -68,7 +71,7 @@ window.onload = function(){
                 }
             },
   		});
-        
+
         document.querySelectorAll('.tabulator-paginator button').forEach(function(button){
                     button.addEventListener('click', gotoEvents);
                 });
@@ -84,7 +87,7 @@ window.onload = function(){
             eventsTable.setPage(1);
             console.log('No page defined');
         }
-        
+
         refreshFilterDisplay();
 };
 
@@ -174,17 +177,17 @@ function displayLeader(user){
 
 
 function selectActivity(activity_id, element){
-    
+
 
     // Toggle filter
     currentActivityFilter=eventsTable.getFilters().filter(function(i ){ return i['field'] == "activity_type" });
     console.log(currentActivityFilter.length);
-    
+
     // Display all activities
     if (false === activity_id && currentActivityFilter.length != 0)
         eventsTable.removeFilter(currentActivityFilter);
 
-    
+
     if (false !== activity_id){
         filter={field:"activity_type", type:"=", value: activity_id};
         if( currentActivityFilter.length ==0)

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -156,7 +156,7 @@ document.querySelectorAll("input[type=datetime]").forEach(function(input){
                     animate: false,
                     weekStart: 1,
                     locale: "fr",
-                    {% if not event.id  %}
+                    {% if not event.id %}
                     timeHours: 0,
                     timeMinutes: 0,
                     {% endif  %}

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -49,16 +49,16 @@
 
     {# We want to make sure pressing 'Enter' submits the whole form #}
     {# For this add a hidden submit button before 'update_leaders' #}
-    {{form.save_all(id="hidden_save_all", style="visibility:hidden;position:absolute;") }} 
+    {{form.save_all(id="hidden_save_all", style="visibility:hidden;position:absolute;") }}
 
     <h4>Activité et encadrants</h4>
       {{form.update_activity(value=0)}}
-      <div class="inline_field">     
+      <div class="inline_field">
          {{form.multi_activities_mode(onchange="javascript:updateActivity(this)") }}
-         {{form.multi_activities_mode.label}} 
+         {{form.multi_activities_mode.label}}
       </div>
       {% if form.multi_activities_mode.data %}
-         {{form.types.label}} : {{form.types(class="choices")}} 
+         {{form.types.label}} : {{form.types(class="choices")}}
       {% else %}
          {{form.type.label}} : {{ form.type(onchange="javascript:updateActivity(this)") }}<br/>
       {% endif %}
@@ -74,7 +74,7 @@
             {% endwith %}
             <br/>
             <div class="inline_field">
-              {{action.leader_id}}  
+              {{action.leader_id}}
               {% if form.can_remove_leader(event, user)  %}
                 <button class="button delete"  name="{{action.delete.name}}" onclick="javascript:removeRequiredAttributes();" value="y">
                   <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-trash-white.svg') }}"/>
@@ -94,7 +94,7 @@
       </div>
       {{ form.update_leaders(value=0) }}
     </fieldset>
-    
+
     <h4>Informations</h4>
      <label for="title">Titre : </label> {{ form.title(size=200) }}<br/>
      <label for="status">État : </label> {{ form.status }}<br/>
@@ -142,12 +142,12 @@
 <script>
 function updateActivity(element)
 {
-    document.getElementById('update_activity').value=1; 
+    document.getElementById('update_activity').value=1;
     element.form.submit();
 }
 function updateLeaders(element)
 {
-    document.getElementById('update_leaders').value=1; 
+    document.getElementById('update_leaders').value=1;
     element.form.submit();
 }
 
@@ -156,11 +156,15 @@ document.querySelectorAll("input[type=datetime]").forEach(function(input){
                     animate: false,
                     weekStart: 1,
                     locale: "fr",
+                    {% if not event.id  %}
+                    timeHours: 0,
+                    timeMinutes: 0,
+                    {% endif  %}
                     timeStepMinutes: 15,
                     timeSeconds: false,
                     closeButton: false,
                     startOpen: true,
-                    stayOpen: true, 
+                    stayOpen: true,
                     position: "#"+input.parentElement.id,
                     classNames:"form-tail-datetime default",
                 });

--- a/tests.py
+++ b/tests.py
@@ -390,9 +390,7 @@ class TestImportCSV(ModelTest):
         assert event.leaders[0].first_name == "First"
 
 
-
 class TestFormatDate(ModelTest):
-
     def test_format_date(self):
         # Null date
         date_test = None
@@ -400,10 +398,9 @@ class TestFormatDate(ModelTest):
         assert date_format == "N/A"
 
         # le 26 avril à 18h -> le 26 avril
-        date_test = datetime.datetime(2020,4,26,18,0,0)
+        date_test = datetime.datetime(2020, 4, 26, 18, 0, 0)
         date_format = helpers_processor()["format_date"](date_test)
         assert date_format == "dimanche 26 avril 2020"
-
 
     def test_format_time(self):
         # Null date
@@ -412,53 +409,54 @@ class TestFormatDate(ModelTest):
         assert date_format == "N/A"
 
         # le 26 avril à 18h -> 18h00
-        date_test = datetime.datetime(2020,4,26,18,0,0)
+        date_test = datetime.datetime(2020, 4, 26, 18, 0, 0)
         date_format = helpers_processor()["format_time"](date_test)
         assert date_format == "18h00"
 
-
     def test_format_datetime_range(self):
         # le 26 avril
-        start = datetime.datetime(2020,4,26,0,0,0)
-        end = datetime.datetime(2020,4,26,0,0,0)
+        start = datetime.datetime(2020, 4, 26, 0, 0, 0)
+        end = datetime.datetime(2020, 4, 26, 0, 0, 0)
         date_format = helpers_processor()["format_datetime_range"](start, end)
         assert date_format == "dimanche 26 avril 2020"
 
         # le 26 avril à 18h
-        start = datetime.datetime(2020,4,26,18,0,0)
-        end = datetime.datetime(2020,4,26,18,0,0)
+        start = datetime.datetime(2020, 4, 26, 18, 0, 0)
+        end = datetime.datetime(2020, 4, 26, 18, 0, 0)
         date_format = helpers_processor()["format_datetime_range"](start, end)
         assert date_format == "dimanche 26 avril 2020 à 18h00"
 
         # le 26 avril de 8h à 18h30
-        start = datetime.datetime(2020,4,26,8,0,0)
-        end = datetime.datetime(2020,4,26,18,30,0)
+        start = datetime.datetime(2020, 4, 26, 8, 0, 0)
+        end = datetime.datetime(2020, 4, 26, 18, 30, 0)
         date_format = helpers_processor()["format_datetime_range"](start, end)
         assert date_format == "dimanche 26 avril 2020 de 8h00 à 18h30"
 
         # du 26 avril au 27 avril
-        start = datetime.datetime(2020,4,26,0,0,0)
-        end = datetime.datetime(2020,4,27,0,0,0)
+        start = datetime.datetime(2020, 4, 26, 0, 0, 0)
+        end = datetime.datetime(2020, 4, 27, 0, 0, 0)
         date_format = helpers_processor()["format_datetime_range"](start, end)
         assert date_format == "du dimanche 26 avril 2020 au lundi 27 avril 2020"
 
         # du 26 avril à 8h au 27 avril à 18h30
-        start = datetime.datetime(2020,4,26,8,0,0)
-        end = datetime.datetime(2020,4,27,18,30,0)
+        start = datetime.datetime(2020, 4, 26, 8, 0, 0)
+        end = datetime.datetime(2020, 4, 27, 18, 30, 0)
         date_format = helpers_processor()["format_datetime_range"](start, end)
-        assert date_format == "du dimanche 26 avril 2020 à 8h00 au lundi 27 avril 2020 à 18h30"
-
+        assert (
+            date_format
+            == "du dimanche 26 avril 2020 à 8h00 au lundi 27 avril 2020 à 18h30"
+        )
 
     def test_format_date_range(self):
         # le 26 avril de 8h à 18h -> le 26 avril
-        start = datetime.datetime(2020,4,26,8,0,0)
-        end = datetime.datetime(2020,4,26,18,0,0)
+        start = datetime.datetime(2020, 4, 26, 8, 0, 0)
+        end = datetime.datetime(2020, 4, 26, 18, 0, 0)
         date_format = helpers_processor()["format_date_range"](start, end)
         assert date_format == "dim. 26 avr."
 
         # du 26 avril à 8h au 27 avril à 18h30 -> du 26 avril au 27 avril
-        start = datetime.datetime(2020,4,26,8,0,0)
-        end = datetime.datetime(2020,4,27,18,30,0)
+        start = datetime.datetime(2020, 4, 26, 8, 0, 0)
+        end = datetime.datetime(2020, 4, 27, 18, 30, 0)
         date_format = helpers_processor()["format_date_range"](start, end)
         assert date_format == "du dim. 26 avr. au lun. 27 avr."
 

--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,7 @@ from collectives.models import Registration, RegistrationLevels, RegistrationSta
 
 # pylint: enable=C0301
 from collectives.api import find_users_by_fuzzy_name
+from collectives.context_processor import helpers_processor
 from collectives.helpers import current_time
 from collectives.models.user import activity_supervisors
 from collectives.utils.csv import csv_to_events
@@ -387,6 +388,79 @@ class TestImportCSV(ModelTest):
         assert event.num_online_slots == 4
         assert "2322m-1200m-F" in event.rendered_description
         assert event.leaders[0].first_name == "First"
+
+
+
+class TestFormatDate(ModelTest):
+
+    def test_format_date(self):
+        # Null date
+        date_test = None
+        date_format = helpers_processor()["format_date"](date_test)
+        assert date_format == "N/A"
+
+        # le 26 avril à 18h -> le 26 avril
+        date_test = datetime.datetime(2020,4,26,18,0,0)
+        date_format = helpers_processor()["format_date"](date_test)
+        assert date_format == "dimanche 26 avril 2020"
+
+
+    def test_format_time(self):
+        # Null date
+        date_test = None
+        date_format = helpers_processor()["format_time"](date_test)
+        assert date_format == "N/A"
+
+        # le 26 avril à 18h -> 18h00
+        date_test = datetime.datetime(2020,4,26,18,0,0)
+        date_format = helpers_processor()["format_time"](date_test)
+        assert date_format == "18h00"
+
+
+    def test_format_datetime_range(self):
+        # le 26 avril
+        start = datetime.datetime(2020,4,26,0,0,0)
+        end = datetime.datetime(2020,4,26,0,0,0)
+        date_format = helpers_processor()["format_datetime_range"](start, end)
+        assert date_format == "dimanche 26 avril 2020"
+
+        # le 26 avril à 18h
+        start = datetime.datetime(2020,4,26,18,0,0)
+        end = datetime.datetime(2020,4,26,18,0,0)
+        date_format = helpers_processor()["format_datetime_range"](start, end)
+        assert date_format == "dimanche 26 avril 2020 à 18h00"
+
+        # le 26 avril de 8h à 18h30
+        start = datetime.datetime(2020,4,26,8,0,0)
+        end = datetime.datetime(2020,4,26,18,30,0)
+        date_format = helpers_processor()["format_datetime_range"](start, end)
+        assert date_format == "dimanche 26 avril 2020 de 8h00 à 18h30"
+
+        # du 26 avril au 27 avril
+        start = datetime.datetime(2020,4,26,0,0,0)
+        end = datetime.datetime(2020,4,27,0,0,0)
+        date_format = helpers_processor()["format_datetime_range"](start, end)
+        assert date_format == "du dimanche 26 avril 2020 au lundi 27 avril 2020"
+
+        # du 26 avril à 8h au 27 avril à 18h30
+        start = datetime.datetime(2020,4,26,8,0,0)
+        end = datetime.datetime(2020,4,27,18,30,0)
+        date_format = helpers_processor()["format_datetime_range"](start, end)
+        assert date_format == "du dimanche 26 avril 2020 à 8h00 au lundi 27 avril 2020 à 18h30"
+
+
+    def test_format_date_range(self):
+        # le 26 avril de 8h à 18h -> le 26 avril
+        start = datetime.datetime(2020,4,26,8,0,0)
+        end = datetime.datetime(2020,4,26,18,0,0)
+        date_format = helpers_processor()["format_date_range"](start, end)
+        assert date_format == "dim. 26 avr."
+
+        # du 26 avril à 8h au 27 avril à 18h30 -> du 26 avril au 27 avril
+        start = datetime.datetime(2020,4,26,8,0,0)
+        end = datetime.datetime(2020,4,27,18,30,0)
+        date_format = helpers_processor()["format_date_range"](start, end)
+        assert date_format == "du dim. 26 avr. au lun. 27 avr."
 
 
 if __name__ == "__main__":

--- a/tests.py
+++ b/tests.py
@@ -391,7 +391,8 @@ class TestImportCSV(ModelTest):
 
 
 class TestFormatDate(ModelTest):
-    def test_format_date(self):
+    @staticmethod
+    def test_format_date():
         # Null date
         date_test = None
         date_format = helpers_processor()["format_date"](date_test)
@@ -402,7 +403,8 @@ class TestFormatDate(ModelTest):
         date_format = helpers_processor()["format_date"](date_test)
         assert date_format == "dimanche 26 avril 2020"
 
-    def test_format_time(self):
+    @staticmethod
+    def test_format_time():
         # Null date
         date_test = None
         date_format = helpers_processor()["format_time"](date_test)
@@ -413,7 +415,8 @@ class TestFormatDate(ModelTest):
         date_format = helpers_processor()["format_time"](date_test)
         assert date_format == "18h00"
 
-    def test_format_datetime_range(self):
+    @staticmethod
+    def test_format_datetime_range():
         # le 26 avril
         start = datetime.datetime(2020, 4, 26, 0, 0, 0)
         end = datetime.datetime(2020, 4, 26, 0, 0, 0)
@@ -447,7 +450,8 @@ class TestFormatDate(ModelTest):
             == "du dimanche 26 avril 2020 à 8h00 au lundi 27 avril 2020 à 18h30"
         )
 
-    def test_format_date_range(self):
+    @staticmethod
+    def test_format_date_range():
         # le 26 avril de 8h à 18h -> le 26 avril
         start = datetime.datetime(2020, 4, 26, 8, 0, 0)
         end = datetime.datetime(2020, 4, 26, 18, 0, 0)


### PR DESCRIPTION
Des encadrants "se plaignent" ou disent qu'indiquer une heure de début et de fin sur une collective n'est pas opportun. D'autres disent que oui. Ceux qui "se plaignent" mettent du coup des heures bidons genre 1h du mat pour tenter de faire comprendre au participant qu'il faut bien lire la description de la sortie et notamment l'heure de rendez-vous. 

Afin de satisfaire tout le monde, si l'encadrant met "0h00" comme heures de début et fin, les heures ne s'affichent pas dans le titre de la collective