### PR TITLE
[INTERNAL] Fix unit test overriding db

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -354,12 +354,6 @@ class TestImportCSV(ModelTest):
     # pylint: disable=C0301
     csv = "TEST ,740020000001,mardi26,mardi 26 novembre 2019,26/11/19 7:00,mardi 26 novembre 2019,26/11/19 7:00,19/11/19 7:00,25/11/19 12:00, ,Aiguille des Calvaires,Aravis, ,2322,1200,F, , ,8,4"
 
-    def create_app(self):
-
-        # pass in test configuration
-        app = create_app()
-        return app
-
     def test_csv_import(self):
 
         user1 = User(


### PR DESCRIPTION
The `TestImportCSV` unit test was overloading the `create_app` from `ModelTest`, thus removing the part that sets the SqlAlchemy URI to a temporary db, and causing havok on the usual database