### PR TITLE
Conservatively upgrade tabulator to 4.5.3

### DIFF
--- a/collectives/templates/administration.html
+++ b/collectives/templates/administration.html
@@ -4,8 +4,8 @@
 {% block additionalhead %}
 
   {# Tabulator: for tables#}
-  <link href="https://unpkg.com/tabulator-tables@4.5.1/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
-  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.min.js"></script>
+  <link href="https://unpkg.com/tabulator-tables@4.5.3/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.3/dist/js/tabulator.min.js"></script>
 
   {# Specific for this page #}
   <script>const filters =  {{ filters |safe }}</script>

--- a/collectives/templates/index.html
+++ b/collectives/templates/index.html
@@ -11,8 +11,8 @@
 
 
   {# Tabulator: for tables#}
-  <link href="https://unpkg.com/tabulator-tables@4.5.1/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
-  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.js"></script>
+  <link href="https://unpkg.com/tabulator-tables@4.5.3/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.3/dist/js/tabulator.js"></script>
 
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
 

--- a/collectives/templates/leader_profile.html
+++ b/collectives/templates/leader_profile.html
@@ -3,8 +3,8 @@
 {% import 'macros.html' as macros with context %}
 
 {% block additionalhead %}
-  <link href="https://unpkg.com/tabulator-tables@4.5.1/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
-  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.js"></script>
+  <link href="https://unpkg.com/tabulator-tables@4.5.3/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.3/dist/js/tabulator.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
 
   <script>


### PR DESCRIPTION
I found [an existing bug on mobile in the `tabulator` library](https://github.com/olifolkerd/tabulator/issues/2506#issuecomment-562960566) which affected the version we were using. So I'm upgrading the library.

To avoid incompatibility with any of the backend components, I'm being conservative and only upgrading to the latest `4.5.x` minor version: `4.5.3`. 