### PR TITLE
[FIXED] Remove unneeded console.log that was added for debugging

### DIFF
--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -251,7 +251,6 @@ function updatePageURL(){
 }
 
 function gotoEvents(event){
-    console.log(event);
     // if we are not on top during a load, do not mess with page position
     if(window.scrollY > 50 && event.type !== 'click')
         return 0;


### PR DESCRIPTION
This `console.log` was added for debugging [when working on a bug fix](https://github.com/Club-Alpin-Annecy/collectives/pull/195/files#diff-46e11f9d467777f47473d75e1e728e6cR246), but left there. I'm removing it to avoid cluttering the js console