### PR TITLE
Use libsass instead of pyScss

### DIFF
--- a/collectives/__init__.py
+++ b/collectives/__init__.py
@@ -56,9 +56,9 @@ def create_app(config_filename="config"):
         # Initialize asset compilation
         assets = Environment(app)
 
-        filters = "pyscss"
+        filters = "libsass"
         if app.config["ENV"] == "production":
-            filters = "pyscss, cssmin"
+            filters = "libsass, cssmin"
         scss = Bundle("css/all.scss", filters=filters, output="dist/css/all.css")
         assets.register("scss_all", scss)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flask-login
 flask_sqlalchemy
 sqlalchemy-utils
 passlib
-pyscss
+libsass
 flask-wtf
 WTForms-Alchemy
 # See #98


### PR DESCRIPTION
@jnguiot was having a lot of issues with sass compilation on Windows, so switching to a more portable libsass implementation should make things much better