### PR TITLE
[INTERNAL] add the sphinx badge in the README

### DIFF
--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -1,7 +1,7 @@
 # Syntax reference for this file:
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 
-name: sphinx
+name: Documentation
 on: [push]
 
 # https://gist.github.com/c-bata/ed5e7b7f8015502ee5092a3e77937c99

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Actions Status](https://github.com/Club-Alpin-Annecy/collectives/workflows/Linter/badge.svg)](https://github.com/Club-Alpin-Annecy/collectives/actions)
 [![Actions Status](https://github.com/Club-Alpin-Annecy/collectives/workflows/Tests/badge.svg)](https://github.com/Club-Alpin-Annecy/collectives/actions)
+[![Actions Status](https://github.com/Club-Alpin-Annecy/collectives/workflows/Documentation/badge.svg)](https://github.com/Club-Alpin-Annecy/collectives/actions)
 
 # INTRODUCTION
 


### PR DESCRIPTION
Rename the sphinx github workflow to Doc. Sphinx is a technology, not a
product.
Add the Doc badge in the README