### PR TITLE
[FIX] Fix #295 error 500 for expired licenses

### DIFF
--- a/collectives/utils/extranet.py
+++ b/collectives/utils/extranet.py
@@ -251,16 +251,21 @@ class ExtranetApi:
             result = response["verifierUnAdherentReturn"]
 
             if result["existe"] == 1:
-                info.exists = True
-                info.renewal_date = datetime.strptime(
-                    result["inscription"], "%Y-%m-%d"
-                ).date()
-            return info
+                try:
+                    info.renewal_date = datetime.strptime(
+                        result["inscription"], "%Y-%m-%d"
+                    ).date()
+                    info.exists = True
+                except ValueError:
+                    # Date parsing as failed, this happens for exprired licenses
+                    # which return '0000-00-00' as date
+                    # In that case simply return an invalid license
+                    pass
 
         except pysimplesoap.client.SoapFault as err:
             print("Extranet API error: {}".format(err), file=stderr)
 
-        return LicenseInfo()
+        return info
 
     def fetch_user_info(self, license_number):
         """ Get user information on a license from FFCAM server.


### PR DESCRIPTION
`strptime` lève une exception pour la date '0000-00-00' qui est retournée pour les licences expirées (l'an 0 n'existe pas)