### PR TITLE
[INTERNAL] workflows: trigger in push and pull requests.

### DIFF
--- a/.github/workflows/push_lint.yml
+++ b/.github/workflows/push_lint.yml
@@ -1,6 +1,6 @@
 name: Linter
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/push_test.yml
+++ b/.github/workflows/push_test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -2,7 +2,7 @@
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 
 name: Documentation
-on: [push]
+on: [push, pull_request]
 
 # https://gist.github.com/c-bata/ed5e7b7f8015502ee5092a3e77937c99
 jobs:


### PR DESCRIPTION
original workflow names reflected the trigger ("push_" prefix). Not
valid but not really needed to rename anyway..