### PR TITLE
Differentiate SMTP login and SMTP sender address

### DIFF
--- a/collectives/utils/mail.py
+++ b/collectives/utils/mail.py
@@ -64,7 +64,7 @@ def send_mail_threaded(app, **kwargs):
         s = smtplib.SMTP(host=config["SMTP_HOST"], port=config["SMTP_PORT"])
 
         s.starttls()
-        s.login(config["SMTP_LOGIN"], config["SMTP_PASSWORD"])
+        s.login(config["SMTP_LOGIN"] or config["SMTP_ADDRESS"], config["SMTP_PASSWORD"])
 
         msg = MIMEMultipart()
 

--- a/collectives/utils/mail.py
+++ b/collectives/utils/mail.py
@@ -5,7 +5,8 @@ DKIM. Conf are taken from app :py:mod:`config`:
 
 - :py:data:`config.SMTP_HOST`: Hostname of SMTP server
 - :py:data:`config.SMTP_PORT`: Connexion port to SMTP server
-- :py:data:`config.SMTP_ADDRESS`: Login and return address. Also used to set DKIM domain
+- :py:data:`config.SMTP_ADDRESS`: Sender address. Also used to set DKIM domain
+- :py:data:`config.SMTP_LOGIN`: Login of SMTP server
 - :py:data:`config.SMTP_PASSWORD`: Password of SMTP server
 - :py:data:`config.DKIM_SELECTOR`: DKIM selector, usually default
 - :py:data:`config.DKIM_KEY`: DKIM private key as PEM format
@@ -63,7 +64,7 @@ def send_mail_threaded(app, **kwargs):
         s = smtplib.SMTP(host=config["SMTP_HOST"], port=config["SMTP_PORT"])
 
         s.starttls()
-        s.login(config["SMTP_ADDRESS"], config["SMTP_PASSWORD"])
+        s.login(config["SMTP_LOGIN"], config["SMTP_PASSWORD"])
 
         msg = MIMEMultipart()
 

--- a/config.py
+++ b/config.py
@@ -130,12 +130,19 @@ SMTP_PORT = environ.get("SMTP_PORT") or 25
 :type: int
 """
 SMTP_ADDRESS = environ.get("SMTP_ADDRESS") or "noreply@example.org"
-"""Sending address to send adminsitration mails
+"""Sending address to send administration mails
 
-Will be used as a reply address and a SMTP login
+Will be used as a reply address
+
+:type: string
+"""
+SMTP_LOGIN = environ.get("SMTP_LOGIN") or "noreply@example.org"
+"""SMTP login to be used
+
+:type: string
 """
 SMTP_PASSWORD = environ.get("SMTP_PASSWORD") or ""
-"""SMTP password to be used along SMTP_ADDRESS as login
+"""SMTP password to be used along SMTP_LOGIN as login
 
 :type: string
 """

--- a/config.py
+++ b/config.py
@@ -136,7 +136,7 @@ Will be used as a reply address
 
 :type: string
 """
-SMTP_LOGIN = environ.get("SMTP_LOGIN") or "noreply@example.org"
+SMTP_LOGIN = environ.get("SMTP_LOGIN") or None
 """SMTP login to be used
 
 :type: string


### PR DESCRIPTION
Différencier le login SMTP de l'adresse d'émission afin d'utiliser des providers de mail type Mailjet