### PR TITLE
Do not populate db when running migrations. Avoids truncation error

### DIFF
--- a/collectives/__init__.py
+++ b/collectives/__init__.py
@@ -53,7 +53,7 @@ def is_running_migration(ctx):
 
 def populate_db(app):
     """Populates the database with admin account and activities,
-    if an only if we're not currently running a db migration command
+    if and only if we're not currently running a db migration command
 
     :param app: The Flask application
     :type app: :py:class:`flask.Application`

--- a/collectives/__init__.py
+++ b/collectives/__init__.py
@@ -18,6 +18,8 @@ from flask_login import LoginManager, current_user
 from flask_migrate import Migrate
 from flask_statistics import Statistics
 
+from click import pass_context
+
 from . import models, api, forms
 from .routes import (
     root,
@@ -31,6 +33,45 @@ from .routes import (
 )
 from .routes import activity_supervison
 from .utils import extranet, init, jinja, error, access, payline, statistics
+
+
+@pass_context
+def is_running_migration(ctx):
+    """Detects whether we are running a migration command
+
+    :param ctx: The current click context
+    :type ctx: :py:class:`cli.Context`
+    :return: True if running  a migration
+    :rtype: False
+    """
+    while ctx is not None:
+        if ctx.command and ctx.command.name == "db":
+            return True
+        ctx = ctx.parent
+    return False
+
+
+def populate_db(app):
+    """Populates the database with admin account and activities,
+    if an only if we're not currently running a db migration command
+
+    :param app: The Flask application
+    :type app: :py:class:`flask.Application`
+    """
+    try:
+        # pylint: disable=E1120
+        running_migration = is_running_migration()
+    except RuntimeError:
+        # There is no active CLI context
+        running_migration = False
+
+    if running_migration:
+        print("Migration detected, skipping populating database")
+        return
+
+    print("Populating database with initial values")
+    auth.init_admin(app)
+    init.activity_types(app)
 
 
 def create_app(config_filename="config"):
@@ -108,9 +149,7 @@ def create_app(config_filename="config"):
         # Initialize DB
         # models.db.create_all()
 
-        # Create admin user
-        auth.init_admin(app)
-        init.activity_types(app)
+        populate_db(app)
 
         if app.config["STATISTICS_ENABLED"]:
             Statistics(


### PR DESCRIPTION
Corrige les erreurs liées à la migration des trigrammes:
de facon plus générale n'initialise plus le compte administrateur/activités lorsqu'on lange une commande de migration comme `flask db upgrade`