### PR TITLE
Store payment metadata in Payline

### DIFF
--- a/cli_test_payline.py
+++ b/cli_test_payline.py
@@ -16,7 +16,12 @@ def doWebPayment():
     order.payment_id = 2
     order.amount_in_cents = "10000"
     order.date = "05/05/2020 00:05"
-    order.details = {"details": {"ref": "12"}}
+    order.details = {"details": [{"ref": "12"}]}
+    order.metadata = {
+        "ref": "12",
+        "coll": ["name", "Ski' de randonnée"],
+        "coll2": "Ski' de randonnée",
+    }
 
     buyer = payline.BuyerInfo()
 

--- a/collectives/routes/payment.py
+++ b/collectives/routes/payment.py
@@ -440,7 +440,7 @@ def request_payment(payment_id):
     payment_request = payline.api.doWebPayment(order_info, buyer_info)
 
     if payment_request is not None:
-        if payment_request.result.payment_status() != PaymentStatus.Approved:
+        if not payment_request.result.is_accepted():
             # Payment request has not been accepted, log error
             current_app.logger.error(
                 "Payment request error: %s", payment_request.result.__dict__
@@ -549,6 +549,7 @@ def process():
 
     payment = Payment.query.filter_by(processor_token=token).first()
     if payment is None:
+        current_app.logger.error("Invalid token '%s' for '%s'", token, request.endpoint)
         abort(500)
 
     if payment.status != PaymentStatus.Initiated:

--- a/collectives/utils/misc.py
+++ b/collectives/utils/misc.py
@@ -2,6 +2,7 @@
 
 """
 import functools
+import unicodedata
 from flask import request
 
 
@@ -51,3 +52,29 @@ def isMobileUser():
         return True
 
     return False
+
+
+def to_ascii(value):
+    """Convert an unicode string to ASCII, drop characters that can't be converted
+
+    :param value: Inpout string
+    :type value: str
+    :return: ASCII string
+    :rtype: str
+    """
+    return (
+        unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    )
+
+
+def truncate_string(string, max_len):
+    """Truncates a string to maximum length
+
+    :param string: Input string
+    :type string: str
+    :param max_len: Maximum length
+    :type max_len: int
+    :return: Truncated string
+    :rtype: str
+    """
+    return string if len(string) <= max_len else string[:max_len]

--- a/collectives/utils/misc.py
+++ b/collectives/utils/misc.py
@@ -57,24 +57,13 @@ def isMobileUser():
 def to_ascii(value):
     """Convert an unicode string to ASCII, drop characters that can't be converted
 
-    :param value: Inpout string
+    :param value: Input string
     :type value: str
     :return: ASCII string
     :rtype: str
     """
     return (
-        unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+        unicodedata.normalize("NFKD", str(value))
+        .encode("ascii", "ignore")
+        .decode("ascii")
     )
-
-
-def truncate_string(string, max_len):
-    """Truncates a string to maximum length
-
-    :param string: Input string
-    :type string: str
-    :param max_len: Maximum length
-    :type max_len: int
-    :return: Truncated string
-    :rtype: str
-    """
-    return string if len(string) <= max_len else string[:max_len]

--- a/collectives/utils/payline.py
+++ b/collectives/utils/payline.py
@@ -13,7 +13,7 @@ from pysimplesoap.client import SoapClient
 
 from ..models.payment import PaymentStatus
 from .time import format_date
-from .misc import truncate_string, to_ascii
+from .misc import to_ascii
 
 PAYLINE_VERSION = 26
 """ Version of payline API
@@ -343,7 +343,8 @@ class OrderInfo:
                 kv.append({"key": k, "value": v})
 
         for pair in kv:
-            pair["value"] = truncate_string(to_ascii(pair["value"]), 50)
+            ascii_val = to_ascii(pair["value"])
+            pair["value"] = ascii_val[:50]
 
         return {"privateData": kv}
 
@@ -358,13 +359,14 @@ class OrderInfo:
             self.amount_in_cents = (payment.amount_charged * 100).to_integral_exact()
             self.date = payment.creation_time.strftime("%d/%m/%Y %H:%M")
             item_details = {
-                "ref": f"{payment.price.id}",
+                "ref": payment.price.id,
                 "comment": f"{payment.item.event.title} -- {payment.item.title} -- {payment.price.title}",
-                "price": f"{self.amount_in_cents}",
+                "price": self.amount_in_cents,
             }
             self.details = {"details": [item_details]}
             self.metadata = {
                 "collective": payment.item.event.title,
+                "collective_id": payment.item.event.id,
                 "date": format_date(payment.item.event.start),
                 "activite": [a.name for a in payment.item.event.activity_types],
                 "objet": payment.item.title,

--- a/collectives/utils/url.py
+++ b/collectives/utils/url.py
@@ -2,7 +2,8 @@
 Module which contains various helping functions for url management.
 """
 import re
-import unicodedata
+
+from .misc import to_ascii
 
 
 def slugify(value):
@@ -16,6 +17,6 @@ def slugify(value):
     _slugify_strip_re = re.compile(r"[^\w\s-]")
     _slugify_hyphenate_re = re.compile(r"[-\s]+")
 
-    value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore")
-    value = _slugify_strip_re.sub("", value.decode("ascii")).strip().lower()
+    value = to_ascii(value)
+    value = _slugify_strip_re.sub("", value).strip().lower()
     return _slugify_hyphenate_re.sub("-", value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ flask-marshmallow
 marshmallow-sqlalchemy
 Flask-Images
 markdown
-pysimplesoap
+# Grab pysimplesoap from Github to get list serialization fixes
+git+https://github.com/pysimplesoap/pysimplesoap.git@ad03a21cafab982eed321553c4bfcda1755182eb#egg=pysimplesoap
 pymysql
 dkimpy
 email_validator


### PR DESCRIPTION
Le but de cette PR est de stocker plus d'infos relatives au paiement  (quelle collective, date, encadrants etc) coté Payline, afin de permettre de retrouver à quoi correspondent les paiements si on a un crash BD. 
Pour  cela on remplit les champ "privateDataList", qui est un "faux" dictionnaire (une liste de paires "key" + "value"). La dernière version Pip de PySImpleSoap (qui date de 2014) ne supportait pas ce type de données, je l'ai remplacé par une version Github plus récente.