### PR TITLE
[FIX] Display 25 events by default

### DIFF
--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -35,8 +35,8 @@ function buildEventsTable() {
                 eventsTable.setGroupBy(sorters[0]['field']);
         },
         pagination : 'remote',
-        paginationSize : 10,
-        paginationSizeSelector:[10, 25, 50, 100],
+        paginationSize : 25,
+        paginationSizeSelector:[25, 50, 100],
         pageLoaded :  updatePageURL,
 
         initialSort: [ {column:"start", dir:"asc"}],


### PR DESCRIPTION
Beaucoup de retours indiquant que l'affichage de 10 collectives est trop peu et que la pagination est "complexe".
Je propose de mettre d'aficher 25 collectives par défaut. Je ne pense pas que cela impactera les performances d'affchage