### PR TITLE
fix/376: [Robustesse] Vérifier si la date d'expiration de la licence n'est pas null

### DIFF
--- a/collectives/models/user.py
+++ b/collectives/models/user.py
@@ -348,6 +348,8 @@ class User(db.Model, UserMixin):
         if self.is_test:
             # Test users licenses never expire
             return True
+        if self.license_expiry_date is None:
+            return False
         return self.license_expiry_date > time.date()
 
     def is_youth(self):


### PR DESCRIPTION
fix #376 