### PR TITLE
[FIX] #428

### DIFF
--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -703,6 +703,17 @@ class Event(db.Model):
 
         return self.has_free_online_slots() and self.is_registration_open_at_time(time)
 
+    def dates_intersect(self, start, end):
+        """Check if a specified timespan and the event timespan intersects
+        :return: True if timespans intersects
+        :rtype: boolean"""
+        return (
+            (self.start <= end)
+            and (self.start <= self.end)
+            and (start <= self.end)
+            and (start <= end)
+        )
+
     # Status
     def is_confirmed(self):
         """Check if this event is confirmed.

--- a/collectives/models/user.py
+++ b/collectives/models/user.py
@@ -605,6 +605,26 @@ class User(db.Model, UserMixin):
                 return False
         return True
 
+    def can_register_on(self, start, end, excluded_event_id=None):
+        """Check if user is already registered to an event on a specified timespan
+
+        :param start: Start of the timespan
+        :type start: :py:class:`datetime.datetime`
+        :param end: End of the timespan
+        :type end: :py:class:`datetime.datetime`
+        :param excluded_event_id: Event id to exclude (often the event being edited)
+        :type excluded_event_id: int
+        :return: True if user can register on the specified timespan.
+        :rtype: boolean
+        """
+        for regis in self.registrations:
+            event = regis.event
+            if event.id == excluded_event_id:
+                continue
+            if regis.is_active() and event.dates_intersect(start, end):
+                return False
+        return True
+
     def led_activities(self):
         """Get activities the user can lead.
 

--- a/collectives/models/user.py
+++ b/collectives/models/user.py
@@ -10,7 +10,7 @@ from sqlalchemy_utils import PasswordType
 from sqlalchemy.orm import validates
 from flask_uploads import UploadSet, IMAGES
 from wtforms.validators import Email
-from ..models.event import event_leaders, Event
+from ..models.event import Event
 from .globals import db
 from .role import RoleIds, Role
 from .activitytype import ActivityType
@@ -594,13 +594,13 @@ class User(db.Model, UserMixin):
         :return: True if user can lead on the specified timespan.
         :rtype: boolean
         """
-        query = db.session.query(event_leaders).filter(
-            event_leaders.c.user_id == self.id
-        )
-        query = query.filter(event_leaders.c.event_id != excluded_event_id)
-        leadings = query.all()
-        for lead in leadings:
-            event = Event.query.get(lead.event_id)
+
+        query = db.session.query(Event)
+        query = query.filter(Event.leaders.contains(self))
+        query = query.filter(Event.id != excluded_event_id)
+        events = query.all()
+
+        for event in events:
             if event.is_confirmed() and event.dates_intersect(start, end):
                 return False
         return True

--- a/collectives/models/user.py
+++ b/collectives/models/user.py
@@ -10,7 +10,7 @@ from sqlalchemy_utils import PasswordType
 from sqlalchemy.orm import validates
 from flask_uploads import UploadSet, IMAGES
 from wtforms.validators import Email
-
+from ..models.event import event_leaders, Event
 from .globals import db
 from .role import RoleIds, Role
 from .activitytype import ActivityType
@@ -581,6 +581,29 @@ class User(db.Model, UserMixin):
         :rtype: boolean
         """
         return self.has_role_for_activity([RoleIds.ActivitySupervisor], activity_id)
+
+    def can_lead_on(self, start, end, excluded_event_id=None):
+        """Check if user is already leading an event on a specified timespan
+
+        :param start: Start of the timespan
+        :type start: :py:class:`datetime.datetime`
+        :param end: End of the timespan
+        :type end: :py:class:`datetime.datetime`
+        :param excluded_event_id: Event id to exclude (often the event being edited)
+        :type excluded_event_id: int
+        :return: True if user can lead on the specified timespan.
+        :rtype: boolean
+        """
+        query = db.session.query(event_leaders).filter(
+            event_leaders.c.user_id == self.id
+        )
+        query = query.filter(event_leaders.c.event_id != excluded_event_id)
+        leadings = query.all()
+        for lead in leadings:
+            event = Event.query.get(lead.event_id)
+            if event.is_confirmed() and event.dates_intersect(start, end):
+                return False
+        return True
 
     def led_activities(self):
         """Get activities the user can lead.

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -395,6 +395,10 @@ def manage_event(event_id=None):
     if not validate_dates_and_slots(trial_event):
         return render_template("editevent.html", event=event, form=form)
 
+    if not current_user.can_lead_on(trial_event.start, trial_event.end, event_id):
+        flash("Vous encadrer déjà une activité à cette date", "error")
+        return render_template("editevent.html", event=event, form=form)
+
     has_new_activity = any(a not in event.activity_types for a in tentative_activities)
 
     tentative_leaders_set = set(tentative_leaders)

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -414,10 +414,7 @@ def manage_event(event_id=None):
     # Check if leaders don't already lead an activity during the event
     for leader in tentative_leaders_set:
         if not leader.can_lead_on(trial_event.start, trial_event.end, event_id):
-            flash(
-                f"L'encadrant {leader.full_name()} encadre déjà une activité à cette date",
-                "error",
-            )
+            flash(f"{leader.full_name()} encadre déjà une activité à cette date")
             return render_template("editevent.html", event=event, form=form)
 
     # If event has not been created yet use current activities to check rights
@@ -534,12 +531,10 @@ def self_register(event_id):
 
     now = current_time()
     if not event or not event.can_self_register(current_user, now):
-        flash("Vous ne pouvez pas vous inscrire vous-même.", "error")
+        flash("Vous ne pouvez pas vous inscrire vous-même.")
         return redirect(url_for("event.view_event", event_id=event_id))
-    print("Test date")
     if not current_user.can_register_on(event.start, event.end, event_id):
-        print("Date invalide !")
-        flash("Vous participer déjà une activité à cette date", "error")
+        flash("Vous participer déjà une activité à cette date")
         return redirect(url_for("event.view_event", event_id=event_id))
 
     if not event.requires_payment():


### PR DESCRIPTION
Affichage d'un message d'erreur lorsque l'encadrant tente d'encadrer plusieurs activités en même temps
Fonctionne aussi pour l'édition de collective
Suggestion : Est ce que je devrais mettre la méthode `date_intersect` dans le fichier `utils/time.py` ?
Suggestion 2 : Je ne comprends pas pourquoi la table `event_leaders` n'est pas une classe modèle ? Il sera pertinent d'en faire une classe pour y ajouter des méthodes, mais surtout pour simplifier les requêtes sql !  