### PR TITLE
[FIX] Fix #487 and #507: export payments

### DIFF
--- a/collectives/routes/payment.py
+++ b/collectives/routes/payment.py
@@ -271,13 +271,16 @@ def export_payments(event_id=None):
     for payment in payments:
         payment.payment_type_str = payment.payment_type.display_name()
         payment.payment_status_str = payment.status.display_name()
-        ws.append([str(deepgetattr(payment, field, "-")) for field in FIELDS])
+        ws.append([deepgetattr(payment, field, "-") for field in FIELDS])
 
     # set column width
     for c in "CDEFGHJL":
         ws.column_dimensions[c].width = 25
     for c in "ABIKMN":
         ws.column_dimensions[c].width = 16
+
+    # set "Amount paid" column format
+    ws.column_dimensions["N"].number_format = "#,##0.00€"
 
     out = BytesIO()
     wb.save(out)

--- a/collectives/routes/payment.py
+++ b/collectives/routes/payment.py
@@ -246,6 +246,7 @@ def export_payments(event_id=None):
     wb = Workbook()
     ws = wb.active
     FIELDS = {
+        "item.event.event_type.name": "Type d'événement",
         "item.event.activity_type_names": "Activités",
         "item.event.main_leader.first_name": "Prénom encadrant",
         "item.event.main_leader.last_name": "Nom encadrant",
@@ -273,9 +274,9 @@ def export_payments(event_id=None):
         ws.append([str(deepgetattr(payment, field, "-")) for field in FIELDS])
 
     # set column width
-    for c in "BCDEFGIK":
+    for c in "CDEFGHJL":
         ws.column_dimensions[c].width = 25
-    for c in "AHJLM":
+    for c in "ABIKMN":
         ws.column_dimensions[c].width = 16
 
     out = BytesIO()

--- a/collectives/routes/payment.py
+++ b/collectives/routes/payment.py
@@ -262,7 +262,6 @@ def export_payments(event_id=None):
         "amount_paid": "Prix payé",
         "finalization_time": "Date du paiement",
         "payment_status_str": "État",
-        "refund_time": "Date de remboursement",
         "payment_type_str": "Type",
         "processor_order_ref": "Référence",
     }
@@ -274,7 +273,7 @@ def export_payments(event_id=None):
         ws.append([deepgetattr(payment, field, "-") for field in FIELDS])
 
     # set column width
-    for c in "CDEFGHJL":
+    for c in "CDEFGHJLOR":
         ws.column_dimensions[c].width = 25
     for c in "ABIKMN":
         ws.column_dimensions[c].width = 16


### PR DESCRIPTION
Quelques améliorations / corrections sur l'export des paiements:

* Ajout du type d'événement
* Suppression d'un "forçage" en string de tous les champs afin d'exporter un paiement en float + ajout de la monnaie €
* Suppression de la colonne "Date de remboursement": fonctionnalité non supportée prêtant à confusion: les gens pensent qu'une fois le remboursement réalisé sur Monext la date apparaissait automatiquement sur le site des collectives
* Redimensionnement de certaines colonnes