### PR TITLE
Fix and improvement of waiting list

### DIFF
--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -499,6 +499,8 @@ class Event(db.Model):
         :return: True if registration is open at ``time``
         :rtype: boolean
         """
+        if self.registration_open_time is None or self.registration_close_time is None:
+            return False
         # pylint: disable=C0301
         return self.registration_open_time <= time <= self.registration_close_time
 

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -166,9 +166,6 @@
     <div class="controls">
       <label for="num_slots">Nombre de participants : </label> {{ form.num_slots(size=4) }}
     </div>
-    <div class="controls">
-      <label for="num_waiting_list">Nombre de places en liste d'attente : </label> {{ form.num_waiting_list(size=4) }}
-    </div>
 
     <div class="dates">
       <h4 class="heading-4">Dates</h4>
@@ -187,6 +184,9 @@
       <h4 class="heading-4">Inscriptions par internet</h4>
       <div class="controls">
         <label for="num_online_slots">Nombre de participants internet : </label> {{ form.num_online_slots(size=4) }}
+      </div>
+      <div class="controls">
+        <label for="num_waiting_list">Nombre de places en liste d'attente : </label> {{ form.num_waiting_list(size=4) }}
       </div>
       <div class="controls">
         <div class="datetimepicker" id="datetimepicker_open"><label for="registration_open_time" >Ouverture des inscriptions : </label>{{ form.registration_open_time(onchange="checkDateOrder();")}}</div>

--- a/collectives/templates/event.html
+++ b/collectives/templates/event.html
@@ -233,7 +233,7 @@
         <p>Les inscriptions sont closes.</p>
         {% endif %}
 
-        {% if event.num_waiting_list != 0 and not event.has_free_online_slots() %}  
+        {% if event.num_waiting_list != 0 and  ( not event.has_free_online_slots() or event.waiting_registrations())  %}  
           <h3 class="heading-3"> Liste d'attente {{event.waiting_registrations() |length }} / {{ event.num_waiting_list }}
               {% if not event.has_free_waiting_slots() %}
                 <span class="tag red">COMPLET</span>


### PR DESCRIPTION
Regarding @fberu remark on https://github.com/Club-Alpin-Annecy/collectives/pull/497#issuecomment-1079929247

> être averti par mail est top. Malheureusement les encadrants ont constaté que des gens s'auto désinscrivent le soir pour le lendemain (des fois à 2h du mat pour un départ à 7h). Dans ce cas là, celui sur liste d'attente est prévenu tardivement qu'il est inscrit et a de grandes chances de ne pas voir la notification. Et du coup l'encadrant grognera le matin au parking parce qu'il n'est pas là

Now, wainting users are automatically updated to subscribed users only if registration time slot is still. After that, subscribing has to be done manually by leader.

Plus, I have fix a 500 error if registration time wasn't set.