### PR TITLE
[INTERNAL] Pin pylint version.

### DIFF
--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -4,7 +4,7 @@ flask-testing
 # See #233
 git+https://github.com/PyCQA/astroid#2.4
 
-pylint
+pylint==2.4.1
 pylint-quotes
 pylint-flask-sqlalchemy
 


### PR DESCRIPTION
La version pylintrc la plus récente (2.15) amène beaucoup de nouvelle norme. Si on veut se mettre en conformité, il faut qu'on passe du temps dessus. En attendant, je pin la version pour pouvoir merger