### PR TITLE
[FIX] Add configuration obsolete management. Remove payline WSDL from db configuration

### DIFF
--- a/collectives/configuration.yaml
+++ b/collectives/configuration.yaml
@@ -33,14 +33,10 @@ Paiements:
         type: Boolean
 
     PAYLINE_WSDL:
-        content: 'collectives/utils/payline.wsdl'
-        description: Path to WDSL file describing Payline WebPayment SOAP API
-        type: ShortString
+        obsolete: true
 
     PAYLINE_DIRECTPAYMENT_WSDL:
-        content: 'collectives/utils/payline_directpayment.wsdl'
-        description: Path to WDSL file describing Payline DirectPayment SOAP API
-        type: ShortString
+        obsolete: true
 
     PAYLINE_MERCHANT_ID:
         content: ""

--- a/collectives/utils/init.py
+++ b/collectives/utils/init.py
@@ -167,6 +167,12 @@ def init_config(force=False, path="collectives/configuration.yaml"):
                 for name, config in config_item.items():
 
                     item = Configuration.get_item(name)
+
+                    if config.get("obsolete", False):
+                        if item is not None:
+                            db.session.delete(item)
+                        continue
+
                     if item is None:
                         item = ConfigurationItem(name)
                         item.content = config["content"]

--- a/collectives/utils/payline.py
+++ b/collectives/utils/payline.py
@@ -519,14 +519,14 @@ class PaylineApi:
 
         try:
             self.webpayment_client = SoapClient(
-                wsdl=Configuration.PAYLINE_WSDL,
+                wsdl=current_app.config["PAYLINE_WSDL"],
                 http_headers={
                     "Authorization": f"Basic {encoded_auth}",
                     "Content-Type": "text/plain",
                 },
             )
             self.directpayment_client = SoapClient(
-                wsdl=Configuration.PAYLINE_DIRECTPAYMENT_WSDL,
+                wsdl=current_app.config["PAYLINE_DIRECTPAYMENT_WSDL"],
                 http_headers={
                     "Authorization": f"Basic {encoded_auth}",
                     "Content-Type": "text/plain",

--- a/config.py
+++ b/config.py
@@ -102,6 +102,24 @@ NB: When using mysql, charset must be specified to allow UTF8 character in test 
 """
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+# Payline
+PAYLINE_WSDL = (
+    environ.get("PAYLINE_WSDL")
+    or f"file://{os.path.join(basedir, 'collectives/utils/payline.wsdl')}"
+)
+"""Path to WDSL file describing Payline WebPayment SOAP API
+
+:type: string
+"""
+
+PAYLINE_DIRECTPAYMENT_WSDL = (
+    environ.get("PAYLINE_DIRECTPAYMENT_WSDL")
+    or f"file://{os.path.join(basedir, 'collectives/utils/payline_directpayment.wsdl')}"
+)
+"""Path to WDSL file describing Payline DirectPayment SOAP API
+
+:type: string
+"""
 
 # Page information
 run = subprocess.run(


### PR DESCRIPTION
Depuis la mise en place de configuration dans la DB, payline ne fonctionne plus car le chemin vers le wsdl n'est pas le bon. Il n'est vraiment utile de changer le chemin du WSSDL dans l'interface, je la supprime donc.