### PR TITLE
[DOCS] Updated run.py to crash if db upgrade command fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ It is based on Flask.
 2. Install Python (this app has been tested with Python 3.8) and pip3
 3. Install required dependencies with pip
     `pip install -r requirements.txt`
-4. Setup local database (sqlite) with
-    `FLASK_APP="collectives:create_app" flask db upgrade`
-5. Run the development server (it will be available at http://localhost:5000)
+4. Run the development server (it will be available at http://localhost:5000)
     `./run.py`
     (do not run this in production)
 

--- a/run.py
+++ b/run.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
+import subprocess
 import os
 import collectives
 
 if __name__ == "__main__":
     # Systematic upgrade of the db
     os.environ["FLASK_APP"] = "collectives:create_app"
-    os.system("flask db upgrade")
+    subprocess.run(["flask db upgrade"], shell=True, check=True)
     collectives.create_app().run(debug=True)


### PR DESCRIPTION
Voir  #538 

J'ai trouvé une autre façon d'appeler le process `flask db migrate` qui crash si jamais cette commande ne passe pas. Je retire par la même occasion l'update de la doc du coup :slightly_smiling_face: 