### PR TITLE
Soap fixes

### DIFF
--- a/collectives/routes/administration.py
+++ b/collectives/routes/administration.py
@@ -320,11 +320,13 @@ def generate_token():
 
     # Check that the license number is valid
     license_number = form.license.data
-    
+
     try:
         license_info = extranet.api.check_license(license_number)
         if not license_info.exists:
-            flash("Le numéro de licence n'existe pas ou n'a pas été renouvellé", "error")
+            flash(
+                "Le numéro de licence n'existe pas ou n'a pas été renouvellé", "error"
+            )
             return redirect(url_for(".administration"))
 
         # Check that the license number has an email associated to it
@@ -337,9 +339,11 @@ def generate_token():
             )
             return redirect(url_for(".administration"))
     except extranet.ExtranetError:
-        flash("Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement", "error")
+        flash(
+            "Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement",
+            "error",
+        )
         return redirect(url_for(".administration"))
-
 
     # Check whether there is an existing account
     user = User.query.filter_by(license=form.license.data).first()

--- a/collectives/routes/auth.py
+++ b/collectives/routes/auth.py
@@ -1,7 +1,6 @@
 """ Module for user authentification routes. """
 
 import datetime
-import traceback
 
 from flask import flash, render_template, redirect, url_for, request, escape
 from flask import current_app, Blueprint, Markup
@@ -126,9 +125,11 @@ def login():
     try:
         sync_user(user, False)
     except extranet.ExtranetError:
-        flash("Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement", "error")
+        flash(
+            "Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement",
+            "error",
+        )
         return redirect(url_for("auth.login"))
-
 
     if not user.is_active:
         flash(
@@ -246,9 +247,11 @@ def process_confirmation(token_uuid):
             flash("Accès aux données FFCAM impossible actuellement", "error")
             return render_confirmation_form(form, is_recover)
     except extranet.ExtranetError:
-        flash("Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement", "error")
+        flash(
+            "Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement",
+            "error",
+        )
         return render_confirmation_form(form, is_recover)
-
 
     # Synchronize user info from API
     if is_recover:
@@ -362,7 +365,10 @@ def signup():
 
         user_info = extranet.api.fetch_user_info(license_number)
     except extranet.ExtranetError:
-        flash("Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement", "error")
+        flash(
+            "Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement",
+            "error",
+        )
         return render_signup_form(form, is_recover)
 
     if user_info.email == None:

--- a/collectives/routes/profile.py
+++ b/collectives/routes/profile.py
@@ -13,6 +13,7 @@ from flask import Blueprint
 from flask_login import current_user
 from flask_images import Images
 
+from ..utils.extranet import ExtranetError
 from ..utils.access import valid_user
 from ..forms import UserForm
 from ..models import User, Role, RoleIds, db
@@ -110,12 +111,15 @@ def update_user():
 @blueprint.route("/user/force_sync", methods=["POST"])
 def force_user_sync():
     """Route to force user synchronisation with extranet"""
-    
+
     try:
         sync_user(current_user, True)
     except ExtranetError:
-        flash("Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement", "error")
-    
+        flash(
+            "Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement",
+            "error",
+        )
+
     return redirect(url_for("profile.show_user", user_id=current_user.id))
 
 

--- a/collectives/routes/profile.py
+++ b/collectives/routes/profile.py
@@ -110,7 +110,12 @@ def update_user():
 @blueprint.route("/user/force_sync", methods=["POST"])
 def force_user_sync():
     """Route to force user synchronisation with extranet"""
-    sync_user(current_user, True)
+    
+    try:
+        sync_user(current_user, True)
+    except ExtranetError:
+        flash("Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement", "error")
+    
     return redirect(url_for("profile.show_user", user_id=current_user.id))
 
 

--- a/collectives/utils/extranet.py
+++ b/collectives/utils/extranet.py
@@ -162,10 +162,12 @@ def sync_user(user, user_info, license_info):
     user.gender = Gender.Man if user_info.qualite == "M" else Gender.Woman
     user.is_test = user_info.is_test
 
+
 class ExtranetError(Exception):
-    """An exception indicating that something has gone wrong with extranet API
-    """
+    """An exception indicating that something has gone wrong with extranet API"""
+
     pass
+
 
 class ExtranetApi:
     """SOAP Client to retrieve information from FFCAM servers."""
@@ -197,8 +199,7 @@ class ExtranetApi:
         self.app = app
 
     def init(self):
-        """Initialize the SOAP Client using `app` config
-        """
+        """Initialize the SOAP Client using `app` config"""
         if not self.soap_client is None:
             # Already initialized
             return
@@ -213,7 +214,7 @@ class ExtranetApi:
         except (IOError, ZeepError) as err:
             current_app.logger.error("Error loading extranet WSDL: {err}")
             current_app.logger.error(traceback.format_stack())
-            raise ExtranetError()
+            raise ExtranetError() from err
 
         self.auth_info = soap_client.service.auth()
         self.auth_info["utilisateur"] = Configuration.EXTRANET_ACCOUNT_ID
@@ -257,7 +258,7 @@ class ExtranetApi:
                 f"Error calling extranet 'verifierUnAdherent' : {err}"
             )
             current_app.logger.error(traceback.format_stack())
-            raise ExtranetError()
+            raise ExtranetError() from err
 
         if result["existe"] == 1:
             try:
@@ -302,7 +303,7 @@ class ExtranetApi:
                 f"Error calling extranet 'extractionAdherent' : {err}"
             )
             current_app.logger.error(traceback.format_stack())
-            raise ExtranetError()
+            raise ExtranetError() from err
 
         info.first_name = result["prenom"]
         info.last_name = result["nom"]

--- a/collectives/utils/extranet.py
+++ b/collectives/utils/extranet.py
@@ -212,7 +212,7 @@ class ExtranetApi:
         try:
             soap_client = Client(wsdl=config["EXTRANET_WSDL"])
         except (IOError, ZeepError) as err:
-            current_app.logger.error("Error loading extranet WSDL: {err}")
+            current_app.logger.error(f"Error loading extranet WSDL: {err}")
             current_app.logger.error(traceback.format_stack())
             raise ExtranetError() from err
 

--- a/collectives/utils/payline.py
+++ b/collectives/utils/payline.py
@@ -592,10 +592,10 @@ class PaylineApi:
                 ],
                 buyer={
                     "title": buyer_info.title,
-                    "lastName": buyer_info.lastName,
-                    "firstName": buyer_info.firstName,
+                    "lastName": buyer_info.last_name,
+                    "firstName": buyer_info.first_name,
                     "email": buyer_info.email,
-                    "birthDate": buyer_info.birthDate,
+                    "birthDate": buyer_info.birth_date,
                 },
                 merchantName=self.payline_merchant_name,
                 privateDataList=order_info.private_data(),


### PR DESCRIPTION
 - Supprime les erreur 500 lors des erreurs extranet: log l'erreur et affiche un message non spécifique à l'utilisateur
 - (Plus important) Corrige les paramètres Payline suite au passage en snake_case

A la base je voulais passer tout Payline sous zeep, mais il y'a une parse erreur sur un message de retour... je reverrai ça plus tard