### PR TITLE
[INTERNAL] Refactor event and price restrictions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "esbonio.sphinx.confDir": ""
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,5 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "esbonio.sphinx.confDir": ""
+    "python.testing.pytestEnabled": true
 }

--- a/collectives/forms/payment.py
+++ b/collectives/forms/payment.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from flask import current_app
 from flask_wtf import FlaskForm
-from wtforms import SubmitField, StringField, DecimalField, FormField, FieldList
+from wtforms import SubmitField, StringField, DecimalField, FormField, FieldList, IntegerField
 from wtforms import HiddenField, BooleanField, SelectField
 from wtforms.validators import NumberRange, ValidationError, Optional
 from wtforms_alchemy import ModelForm
@@ -50,13 +50,14 @@ class ItemPriceForm(ModelForm, AmountForm):
             "title",
             "start_date",
             "end_date",
-            "license_types",
             "max_uses",
-            "leader_only",
-            "parent_event_id",
         ]
 
     delete = BooleanField("Supprimer")
+
+    license_types = StringField("Catégories de license")
+    leader_only = BooleanField("Tarif encadrant")
+    parent_event_id = IntegerField("Événement parent", validators=[Optional()])
 
     price_id = HiddenField()
     total_use_count = 0
@@ -183,11 +184,12 @@ class NewItemPriceForm(ModelForm, AmountForm):
             "title",
             "start_date",
             "end_date",
-            "license_types",
             "max_uses",
-            "leader_only",
-            "parent_event_id",
         ]
+
+    license_types = StringField("Catégories de license")
+    leader_only = BooleanField("Tarif encadrant")
+    parent_event_id = IntegerField("Événement parent", validators=[Optional()])
 
     item_title = StringField("Intitulé du nouvel objet")
     existing_item = SelectField(

--- a/collectives/forms/payment.py
+++ b/collectives/forms/payment.py
@@ -3,7 +3,14 @@ from decimal import Decimal
 
 from flask import current_app
 from flask_wtf import FlaskForm
-from wtforms import SubmitField, StringField, DecimalField, FormField, FieldList, IntegerField
+from wtforms import (
+    SubmitField,
+    StringField,
+    DecimalField,
+    FormField,
+    FieldList,
+    IntegerField,
+)
 from wtforms import HiddenField, BooleanField, SelectField
 from wtforms.validators import NumberRange, ValidationError, Optional
 from wtforms_alchemy import ModelForm

--- a/collectives/models/__init__.py
+++ b/collectives/models/__init__.py
@@ -22,3 +22,5 @@ from collectives.models.reservation import ReservationStatus
 from collectives.models.role import Role, RoleIds
 from collectives.models.upload import UploadedFile, documents
 from collectives.models.user import User, Gender, avatars
+from collectives.models.user_group import UserGroup, GroupEventCondition
+from collectives.models.user_group import GroupLicenseCondition, GroupRoleCondition

--- a/collectives/models/event/misc.py
+++ b/collectives/models/event/misc.py
@@ -113,6 +113,14 @@ class EventMiscMixin:
         )
 
     @property
+    def parent_event(self):
+        """Temporary helper for migrating from parent_event user groups"""
+        parent_event_id = self.parent_event_id
+        if parent_event_id is None:
+            return None
+        return self.query.get(parent_event_id)
+
+    @property
     def parent_event_id(self):
         """Temporary helper for migrating from parent_event_id to user groups"""
         if self._deprecated_parent_event_id:
@@ -142,6 +150,6 @@ class EventMiscMixin:
                 )
                 self.user_group.event_conditions.append(condition)
             else:
-                self.user_group.event_conditions[0].parent_event_id = parent_event_id
+                self.user_group.event_conditions[0].event_id = parent_event_id
 
         self._deprecated_parent_event_id = None

--- a/collectives/models/event/misc.py
+++ b/collectives/models/event/misc.py
@@ -3,7 +3,6 @@
 from flask_uploads import UploadSet, IMAGES
 
 from collectives.models.event.enum import EventStatus
-from collectives.models import db  
 from collectives.utils import render_markdown
 
 
@@ -116,25 +115,33 @@ class EventMiscMixin:
     @property
     def parent_event_id(self):
         """Temporary helper for migrating from parent_event_id to user groups"""
+        if self._deprecated_parent_event_id:
+            # Migrate to new version of attribute
+            self.parent_event_id = self._deprecated_parent_event_id
+
         if self.user_group is None:
-            return None 
+            return None
         if not self.user_group.event_conditions:
-            return None 
+            return None
         return self.user_group.event_conditions[0].event_id
 
+    # pylint: disable=import-outside-toplevel
     @parent_event_id.setter
-    def parent_event_id(self, id):
+    def parent_event_id(self, parent_event_id):
         """Temporary helper for migrating from parent_event_id to user groups"""
-        if id is None:
+        if parent_event_id is None:
             self.user_group = None
         else:
-            from collectives.models import UserGroup, GroupEventCondition
+            from collectives.models.user_group import UserGroup, GroupEventCondition
 
             if self.user_group is None:
                 self.user_group = UserGroup()
             if not self.user_group.event_conditions:
-                condition = GroupEventCondition(event_id = id, is_leader = False)
+                condition = GroupEventCondition(
+                    event_id=parent_event_id, is_leader=False
+                )
                 self.user_group.event_conditions.append(condition)
             else:
-                self.user_group.event_conditions[0].parent_event_id = id
+                self.user_group.event_conditions[0].parent_event_id = parent_event_id
 
+        self._deprecated_parent_event_id = None

--- a/collectives/models/event/model.py
+++ b/collectives/models/event/model.py
@@ -134,11 +134,11 @@ class EventModelMixin:
         return db.Column(db.Integer, db.ForeignKey("users.id"))
 
     @declared_attr
-    def parent_event_id(self):
-        """Primary key of the parent curriculum event
+    def user_group_id(self):
+        """Primary key of the user group to which to restrict registrations
 
         :type: int"""
-        return db.Column(db.Integer, db.ForeignKey("events.id"))
+        return db.Column(db.Integer, db.ForeignKey("user_groups.id"))
 
     @declared_attr
     def event_type_id(self):
@@ -234,15 +234,15 @@ class EventModelMixin:
         )
 
     @declared_attr
-    def parent_event(self):
-        """Parent event
+    def user_group(self):
+        """User Group
 
-        Registrations to this event will we limited to users already registered on the parent event
+        Registrations to this event will we limited to users that are members of this group
 
         :type: :py:class:`collectives.models.event.Event`
         """
         return db.relationship(
-            "Event", backref="children_events", remote_side=[self.id], lazy=True
+            "UserGroup", single_parent=True, lazy=True
         )
 
     @validates("title")

--- a/collectives/models/event/model.py
+++ b/collectives/models/event/model.py
@@ -149,6 +149,13 @@ class EventModelMixin:
         return db.Column(db.Integer, db.ForeignKey("event_types.id"), default=1)
 
     @declared_attr
+    def _deprecated_parent_event_id(self):
+        """[Deprecated] Primary key of the user group to which to restrict registrations
+
+        :type: int"""
+        return db.Column("parent_event_id", db.Integer, db.ForeignKey("events.id"))
+
+    @declared_attr
     def leaders(self):
         """Users who lead this event.
 
@@ -241,9 +248,7 @@ class EventModelMixin:
 
         :type: :py:class:`collectives.models.event.Event`
         """
-        return db.relationship(
-            "UserGroup", single_parent=True, lazy=True
-        )
+        return db.relationship("UserGroup", single_parent=True, lazy=True)
 
     @validates("title")
     def truncate_string(self, key, value):

--- a/collectives/models/event/payment.py
+++ b/collectives/models/event/payment.py
@@ -66,4 +66,6 @@ class EventPaymentMixin:
         :param time_shift: Optionnal shift of copied item prices dates
         :type time_shift: :py:class:`datetime.timedelta`"""
         for payment in source_event.payment_items:
-            self.payment_items.append(payment.copy(time_shift))
+            self.payment_items.append(payment.copy(time_shift,
+                old_event_id = source_event.id,
+                new_event_id = self.id ))

--- a/collectives/models/event/payment.py
+++ b/collectives/models/event/payment.py
@@ -66,6 +66,8 @@ class EventPaymentMixin:
         :param time_shift: Optionnal shift of copied item prices dates
         :type time_shift: :py:class:`datetime.timedelta`"""
         for payment in source_event.payment_items:
-            self.payment_items.append(payment.copy(time_shift,
-                old_event_id = source_event.id,
-                new_event_id = self.id ))
+            self.payment_items.append(
+                payment.copy(
+                    time_shift, old_event_id=source_event.id, new_event_id=self.id
+                )
+            )

--- a/collectives/models/event/registration.py
+++ b/collectives/models/event/registration.py
@@ -4,6 +4,7 @@ from operator import attrgetter
 
 from collectives.models.registration import RegistrationLevels, RegistrationStatus
 
+
 class EventRegistrationMixin:
     """Part of Event class for registration manipulation and check.
 
@@ -214,13 +215,18 @@ class EventRegistrationMixin:
             user, [RegistrationStatus.SelfUnregistered]
         )
 
-    def is_user_in_user_group(self, user : "collectives.models.user.User") -> bool:
+    def is_user_in_user_group(self, user: "collectives.models.user.User") -> bool:
         """Check if a user is part of the event user group
 
         :param user: User which will be tested.
         :return: True if there is no user group or the user is a member of the group
         :rtype: boolean
         """
+
+        if self._deprecated_parent_event_id:
+            # Migrate to new version of attribute
+            self.parent_event_id = self._deprecated_parent_event_id
+
         if self.user_group is None:
             return True
         return self.user_group.contains(user)

--- a/collectives/models/event/registration.py
+++ b/collectives/models/event/registration.py
@@ -4,7 +4,6 @@ from operator import attrgetter
 
 from collectives.models.registration import RegistrationLevels, RegistrationStatus
 
-
 class EventRegistrationMixin:
     """Part of Event class for registration manipulation and check.
 
@@ -215,19 +214,16 @@ class EventRegistrationMixin:
             user, [RegistrationStatus.SelfUnregistered]
         )
 
-    def is_user_registered_to_parent_event(self, user):
-        """Check if a user has a confirmed registration for the parent event
+    def is_user_in_user_group(self, user : "collectives.models.user.User") -> bool:
+        """Check if a user is part of the event user group
 
         :param user: User which will be tested.
-        :type user: :py:class:`collectives.models.user.User`
-        :return: True if there is no parent event or the user is registered with a ``Active`` status
+        :return: True if there is no user group or the user is a member of the group
         :rtype: boolean
         """
-        if self.parent_event is None:
+        if self.user_group is None:
             return True
-        return self.parent_event.is_registered_with_status(
-            user, [RegistrationStatus.Active]
-        )
+        return self.user_group.contains(user)
 
     def can_self_register(self, user, time, waiting=False):
         """Check if a user can self-register.
@@ -254,7 +250,7 @@ class EventRegistrationMixin:
             return False
         if self.is_leader(user) or self.is_registered(user):
             return False
-        if not self.is_user_registered_to_parent_event(user):
+        if not self.is_user_in_user_group(user):
             return False
         if not self.is_registration_open_at_time(time):
             return False

--- a/collectives/models/user/misc.py
+++ b/collectives/models/user/misc.py
@@ -5,7 +5,6 @@ import phonenumbers
 from flask_uploads import UploadSet, IMAGES
 
 from collectives.models.globals import db
-from collectives.models.event import Event, EventType
 from collectives.models.configuration import Configuration
 from collectives.models.registration import Registration
 from collectives.models.reservation import ReservationStatus
@@ -189,6 +188,7 @@ class UserMiscMixin:
         :return: True if user can register on the specified timespan.
         :rtype: boolean
         """
+        from collectives.models.event import Event, EventType
 
         query = db.session.query(Event)
         query = query.filter(Event.start <= end)

--- a/collectives/models/user/misc.py
+++ b/collectives/models/user/misc.py
@@ -188,6 +188,7 @@ class UserMiscMixin:
         :return: True if user can register on the specified timespan.
         :rtype: boolean
         """
+        # pylint: disable=(import-outside-toplevel
         from collectives.models.event import Event, EventType
 
         query = db.session.query(Event)

--- a/collectives/models/user_group.py
+++ b/collectives/models/user_group.py
@@ -1,0 +1,179 @@
+""" Handle dynamic user groups, for restricting or payment options """
+from asyncio import events
+import enum
+from typing import List
+
+from sqlalchemy import and_, or_, true
+
+from collectives.models.globals import db
+
+from collectives.models.role import RoleIds, Role
+from collectives.models.user import User
+from collectives.models.event import Event
+
+
+class GroupRoleCondition(db.Model):
+    """Relationship indicating that group members must have a certain role"""
+
+    __tablename__ = "group_role_conditions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    """Database primary key
+
+    :type: int"""
+
+    group_id = db.Column(
+        db.Integer, db.ForeignKey("user_groups.id"), nullable=False, index=True
+    )
+    """ ID of the group this condition applies to
+
+    :type: int"""
+
+    role_id = db.Column(
+        db.Enum(RoleIds),
+        nullable=True,
+        info={"choices": RoleIds.choices(), "coerce": RoleIds.coerce, "label": "Rôle"},
+    )
+    """ Id of the role that group members must have. If null, any role is allowed
+
+    :type: :py:class:`collectives.models.RoleId``
+    """
+
+    activity_id = db.Column(
+        db.Integer, db.ForeignKey("activity_types.id"), nullable=True
+    )
+    """ ID of the activity to which the user role should relate to. If null, any activity is allowed
+
+    :type: int"""
+
+    def get_condition(self):
+        """:returns: the SQLAlchemy expression corresponding to this condition"""
+        if self.role_id and self.activity_id:
+            return User.roles.any(and_(Role.role_id == self.role_id, Role.activity_id == self.activity_id))
+        if self.role_id:
+            return Role.role_id == self.role_id
+        if self.activity_id:
+            Role.activity_id == self.activity_id
+        return true
+
+class GroupEventCondition(db.Model):
+    """Relationship indicating that group members must participate (or lead) a given event."""
+
+    __tablename__ = "group_event_conditions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    """Database primary key
+
+    :type: int"""
+
+    group_id = db.Column(
+        db.Integer, db.ForeignKey("user_groups.id"), nullable=False, index=True
+    )
+    """ ID of the group this condition applies to
+
+    :type: int"""
+
+    event_id = db.Column(
+        db.Integer, db.ForeignKey("activity_types.id"), nullable=False
+    )
+    """ ID of the activity to which the user role should relate to. 
+
+    :type: int"""
+
+    is_leader = db.Column(
+        db.Boolean, nullable=True
+    )
+    """ Whether group members should be leaders of the activity or normal users.
+    If null, both are allowed.
+
+    :type: int"""
+
+    def get_condition(self):
+        """:returns: the SQLAlchemy expression corresponding to this condition"""
+        if self.is_leader is None:
+            return or_(User.events.any(Event.id == self.event_id), User.led_events.any(Event.id == self.event_id) )
+        if self.is_leader:
+            return User.led_events.any(Event.id == self.event_id)
+
+        return User.events.any(Event.id == self.event_id)
+
+class GroupLicenseCondition(db.Model):
+    """Relationship indicating that group members must have a certain license type"""
+
+    id = db.Column(db.Integer, primary_key=True)
+    """Database primary key
+
+    :type: int"""
+
+    group_id = db.Column(
+        db.Integer, db.ForeignKey("user_groups.id"), nullable=False, index=True
+    )
+    """ ID of the group this condition applies to
+
+    :type: int"""
+
+    license_category = db.Column(db.String(2), info={"label": "Catégorie de licence"})
+    """ User club license category.
+
+    :type: string (2 char)"""
+
+
+class UserGroup(db.Model):
+    """ Dynamically-defined set of users based on various conditions.
+
+        Currently three type of conditions are available:
+
+         - Role: User must have a specific role, optionnaly for a given activity
+         - Event: User must be registered or be a leader to a given event
+         - Licence: Use must have a specific licence type
+
+        Those conditions are multiplicative, i.e. the user must satisfy all conditions ("and").
+        However, within each condition, allowed values are additive ("or")
+        All three types of conditions are also optional.
+
+        For instance, a user group may be defined as follow:
+        Users which have ((the role President) or (the role Leader for activity "Ski")) 
+        and ((lead event "Foo") or (are registered to event "Bar"))
+        
+    """
+    
+    id = db.Column(db.Integer, primary_key=True)
+    """Database primary key
+
+    :type: int"""
+
+    role_conditions = db.relationship("GroupRoleConditions", backref="group", cascade="all, delete")
+    """ List of role conditions associated with this group
+
+    :type: list(:py:class:`collectives.models.user_group.GroupRoleCondition`)
+    """
+
+    event_conditions = db.relationship("GroupEventConditions", backref="group", cascade="all, delete")
+    """ List of event conditions associated with this group
+
+    :type: list(:py:class:`collectives.models.user_group.GroupRoleCondition`)
+    """
+
+    license_conditions = db.relationship("GroupLicenceConditions", backref="group", cascade="all, delete")
+    """ List of license conditions associated with this group
+
+    :type: list(:py:class:`collectives.models.user_group.GroupRoleCondition`)
+    """
+
+
+    def get_members(self) -> List[User]:
+        """:return: the list of group members
+        """
+        query  = User.query
+
+        if self.role_conditions:
+            roles = [role.get_condition() for role in self.role_conditions]
+            query = query.filtee(or_(*roles))
+       
+        if self.event_conditions:
+            events = [event.get_condition() for event in self.event_conditions]
+            query = query.filtee(or_(*events))
+
+        if self.license_conditions:
+            categories = [condition.license_category for condition in self.license_conditions]
+            query = query.filter( User.license_category in categories)

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -507,6 +507,7 @@ def manage_event(event_id=None):
         if duplicated_event != None:
             event.photo = duplicated_event.photo
             event.copy_payment_items(duplicated_event)
+
             db.session.add(event)
             db.session.commit()
 

--- a/collectives/routes/payment.py
+++ b/collectives/routes/payment.py
@@ -94,11 +94,13 @@ def edit_prices(event_id):
                         "info",
                     )
 
-                new_item = PaymentItem(title=new_price_form.item_title.data, event_id = event.id)
+                new_item = PaymentItem(
+                    title=new_price_form.item_title.data, event_id=event.id
+                )
                 new_item.prices.append(new_price)
-                
+
                 db.session.add(new_item)
-            
+
             new_price_form.populate_obj(new_price)
             db.session.add(new_price)
             db.session.commit()

--- a/collectives/routes/payment.py
+++ b/collectives/routes/payment.py
@@ -76,7 +76,6 @@ def edit_prices(event_id):
             new_price = ItemPrice(
                 update_time=current_time(),
             )
-            new_price_form.populate_obj(new_price)
 
             if new_price_form.existing_item.data:
                 new_price.item_id = new_price_form.existing_item.data
@@ -95,11 +94,12 @@ def edit_prices(event_id):
                         "info",
                     )
 
-                new_item = PaymentItem(title=new_price_form.item_title.data)
+                new_item = PaymentItem(title=new_price_form.item_title.data, event_id = event.id)
                 new_item.prices.append(new_price)
-                event.payment_items.append(new_item)
-                db.session.add(event)
+                
                 db.session.add(new_item)
+            
+            new_price_form.populate_obj(new_price)
             db.session.add(new_price)
             db.session.commit()
 

--- a/collectives/templates/event/event.html
+++ b/collectives/templates/event/event.html
@@ -169,11 +169,12 @@
             {% endif %}
             <br/>
         {% endif %}
-        {% if event.user_group and event.user_group.event_conditions%}
-            {# TODO: handle other group conditions #}
+        
+        {% if event.user_group and event.user_group.event_conditions %}
+          {# TODO: handle other group conditions #}
             Les inscriptions en ligne sont restreintes aux participants à la collective
             <a href="{{url_for('.view_event', event_id=event.user_group.event_conditions[0].event_id)}}">{{event.parent_event.title}}</a>
-            {% if event.is_user_registered_to_parent_event(current_user) %}
+            {% if event.user_group.contains(current_user) %}
               dont vous faites partie.
             {% else %}
               dont vous ne faites pas partie.

--- a/collectives/templates/event/event.html
+++ b/collectives/templates/event/event.html
@@ -169,9 +169,10 @@
             {% endif %}
             <br/>
         {% endif %}
-        {% if event.parent_event %}
+        {% if event.user_group and event.user_group.event_conditions%}
+            {# TODO: handle other group conditions #}
             Les inscriptions en ligne sont restreintes aux participants à la collective
-            <a href="{{url_for('.view_event', event_id=event.parent_event.id)}}">{{event.parent_event.title}}</a>
+            <a href="{{url_for('.view_event', event_id=event.user_group.event_conditions[0].event_id)}}">{{event.parent_event.title}}</a>
             {% if event.is_user_registered_to_parent_event(current_user) %}
               dont vous faites partie.
             {% else %}

--- a/collectives/templates/partials/event/payment_item_list.html
+++ b/collectives/templates/partials/event/payment_item_list.html
@@ -34,7 +34,7 @@
                 {%- endif %}
 
                 {%- if(price['parent_event_id']) %}
-                  -<i>  Réservé aux participants de <a href="{{url_for("event.view_event", event_id=price.parent_event.id)}}">{{price.parent_event.title}}</a></i>
+                  -<i>  Réservé aux participants de <a href="{{url_for("event.view_event", event_id=price.parent_event_id)}}">{{price.parent_event.title}}</a></i>
                 {%- endif %}
               
               {%- endif %}

--- a/collectives/templates/payment/edit_prices.html
+++ b/collectives/templates/payment/edit_prices.html
@@ -99,6 +99,7 @@
             {{ field.parent_event_id(style="display:none") }} 
             <input type="text" id="{{ field.parent_event_id.id }}-search" placeholder="Titre ou ID…"/>
           </td>
+          <td> {{ field.max_uses() }} </td>
           <td> {{ field.leader_only() }} </td>
           <td class="actions"> {{field.price_id}} 
           {{field.active_use_count}} actives ({{field.total_use_count}} tot.)

--- a/collectives/utils/csv.py
+++ b/collectives/utils/csv.py
@@ -7,6 +7,7 @@ import csv
 from flask import current_app
 
 from collectives.models import User, Event, db
+from collectives.models.user_group import GroupEventCondition, UserGroup
 from collectives.utils.time import format_date
 
 
@@ -33,7 +34,10 @@ def fill_from_csv(event, row, template):
     if parent_event_id != "":
         if Event.query.get(parent_event_id) is None:
             raise Exception(f"La collective {parent_event_id} n'existe pas")
-        event.parent_event_id = parent_event_id
+        event.user_group = UserGroup()
+        event.user_group.event_conditions.add(
+            GroupEventCondition(event_id=parent_event_id, is_leader=False)
+        )
 
     # Online subscription dates and slots
     if row["places_internet"].strip():

--- a/doc/source/models.rst
+++ b/doc/source/models.rst
@@ -51,6 +51,13 @@ Module ``collectives.models.user``
 
   user
 
+Module ``collectives.models.user_group``
+----------------------------------------
+.. toctree::
+  :maxdepth: 2
+
+  user_group
+
 Module ``collectives.models.payment``
 ---------------------------------------
 .. toctree::

--- a/doc/source/user_group.rst
+++ b/doc/source/user_group.rst
@@ -1,0 +1,5 @@
+
+Module ``collectives.models.user_group``
+========================================
+.. automodule:: collectives.models.user_group
+    :members:

--- a/migrations/versions/604ff8589a3a_add_user_groups.py
+++ b/migrations/versions/604ff8589a3a_add_user_groups.py
@@ -1,0 +1,135 @@
+"""Add UserGrpup and related tables
+
+Revision ID: 604ff8589a3a
+Revises: 03efbbcc54de
+Create Date: 2022-11-13 21:13:05.010246
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "604ff8589a3a"
+down_revision = "03efbbcc54de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "user_groups",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "group_event_conditions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("is_leader", sa.Boolean(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["activity_types.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["user_groups.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_group_event_conditions_group_id"),
+        "group_event_conditions",
+        ["group_id"],
+        unique=False,
+    )
+    op.create_table(
+        "group_license_conditions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.Column("license_category", sa.String(length=2), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["user_groups.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_group_license_conditions_group_id"),
+        "group_license_conditions",
+        ["group_id"],
+        unique=False,
+    )
+    op.create_table(
+        "group_role_conditions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "role_id",
+            sa.Enum(
+                "Moderator",
+                "Administrator",
+                "President",
+                "Technician",
+                "Hotline",
+                "Accountant",
+                "Staff",
+                "EventLeader",
+                "ActivitySupervisor",
+                "Trainee",
+                "EquipmentManager",
+                "EquipmentVolunteer",
+                name="roleids",
+            ),
+            nullable=True,
+        ),
+        sa.Column("activity_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["activity_id"],
+            ["activity_types.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["group_id"],
+            ["user_groups.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_group_role_conditions_group_id"),
+        "group_role_conditions",
+        ["group_id"],
+        unique=False,
+    )
+
+    with op.batch_alter_table("events") as batch_op:
+        batch_op.add_column(sa.Column("user_group_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fkey_user_group_id", "user_groups", ["user_group_id"], ["id"]
+        )
+
+    with op.batch_alter_table("item_prices") as batch_op:
+        batch_op.add_column(sa.Column("user_group_id", sa.Integer(), nullable=True))
+
+        batch_op.alter_column("leader_only", existing_type=sa.Integer(), nullable=True)
+        batch_op.create_foreign_key(
+            "fkey_ip_user_group_id", "user_groups", ["user_group_id"], ["id"]
+        )
+
+def downgrade():
+    with op.batch_alter_table("item_prices") as batch_op:
+        batch_op.drop_constraint("fkey_ip_user_group_id", type_="foreignkey")
+        batch_op.alter_column(
+            "leader_only", existing_type=sa.Integer(), nullable=False
+        )
+        batch_op.drop_column("user_group_id")
+
+    with op.batch_alter_table("events") as batch_op:
+        batch_op.drop_constraint("fkey_user_group_id", type_="foreignkey")
+        batch_op.drop_column("user_group_id")
+        pass
+
+    op.drop_table("group_role_conditions")
+    op.drop_table("group_license_conditions")
+    op.drop_table("group_event_conditions")
+    op.drop_table("user_groups")

--- a/migrations/versions/604ff8589a3a_add_user_groups.py
+++ b/migrations/versions/604ff8589a3a_add_user_groups.py
@@ -116,12 +116,11 @@ def upgrade():
             "fkey_ip_user_group_id", "user_groups", ["user_group_id"], ["id"]
         )
 
+
 def downgrade():
     with op.batch_alter_table("item_prices") as batch_op:
         batch_op.drop_constraint("fkey_ip_user_group_id", type_="foreignkey")
-        batch_op.alter_column(
-            "leader_only", existing_type=sa.Integer(), nullable=False
-        )
+        batch_op.alter_column("leader_only", existing_type=sa.Integer(), nullable=False)
         batch_op.drop_column("user_group_id")
 
     with op.batch_alter_table("events") as batch_op:

--- a/pylintrc
+++ b/pylintrc
@@ -162,7 +162,8 @@ disable=raw-checker-failed,
         too-many-return-statements,
         too-many-instance-attributes,
         unexpected-keyword-arg, #false positive with attachment_filename
-        no-member #False positives with SQLAlchemy
+        no-member, #False positives with SQLAlchemy
+        cyclic-import #False positives with conf.test.py
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/events/test_event.py
+++ b/tests/events/test_event.py
@@ -191,7 +191,7 @@ def test_event_duplication(admin_client, paying_event):
         "event_type",
         "activity_types",
         "tags",
-        "parent_event",
+        "user_group",
     ]
     for attribute in attributes:
         assert getattr(new_event, attribute) == getattr(paying_event, attribute)

--- a/tests/fixtures/event.py
+++ b/tests/fixtures/event.py
@@ -134,9 +134,9 @@ inject_fixture("prototype_paying_event", "paying")
 def paying_event(prototype_paying_event):
     """:returns: An event with associated payment_item and prices"""
 
-    db.session.add(prototype_paying_event)
-    db.session.commit()
-    prototype_paying_event.payment_items.append(payment.payment_item(prototype_paying_event))
+    prototype_paying_event.payment_items.append(
+        payment.payment_item(prototype_paying_event)
+    )
     db.session.add(prototype_paying_event)
     db.session.commit()
     return prototype_paying_event
@@ -149,9 +149,9 @@ inject_fixture("prototype_disabled_paying_event", "disabled paying")
 def disabled_paying_event(prototype_disabled_paying_event):
     """:returns: An event in draft status"""
 
-    db.session.add(prototype_disabled_paying_event)
-    db.session.commit()
-    prototype_disabled_paying_event.payment_items.append(payment.payment_item(prototype_disabled_paying_event))
+    prototype_disabled_paying_event.payment_items.append(
+        payment.payment_item(prototype_disabled_paying_event)
+    )
     db.session.add(prototype_disabled_paying_event)
     db.session.commit()
     return prototype_disabled_paying_event

--- a/tests/fixtures/event.py
+++ b/tests/fixtures/event.py
@@ -134,7 +134,9 @@ inject_fixture("prototype_paying_event", "paying")
 def paying_event(prototype_paying_event):
     """:returns: An event with associated payment_item and prices"""
 
-    prototype_paying_event.payment_items.append(payment.payment_item())
+    db.session.add(prototype_paying_event)
+    db.session.commit()
+    prototype_paying_event.payment_items.append(payment.payment_item(prototype_paying_event))
     db.session.add(prototype_paying_event)
     db.session.commit()
     return prototype_paying_event
@@ -147,7 +149,9 @@ inject_fixture("prototype_disabled_paying_event", "disabled paying")
 def disabled_paying_event(prototype_disabled_paying_event):
     """:returns: An event in draft status"""
 
-    prototype_disabled_paying_event.payment_items.append(payment.payment_item())
+    db.session.add(prototype_disabled_paying_event)
+    db.session.commit()
+    prototype_disabled_paying_event.payment_items.append(payment.payment_item(prototype_disabled_paying_event))
     db.session.add(prototype_disabled_paying_event)
     db.session.commit()
     return prototype_disabled_paying_event

--- a/tests/fixtures/payment.py
+++ b/tests/fixtures/payment.py
@@ -17,9 +17,10 @@ def regular_price():
     return price
 
 
-def leader_price():
+def leader_price(item):
     """:returns: A free ItemPrice only for leaders"""
     price = ItemPrice()
+    price.item = item
     price.amount = 0
     price.title = "Encadrant"
     price.enabled = True
@@ -48,11 +49,12 @@ def disabled_price():
     return price
 
 
-def payment_item():
+def payment_item(event):
     """A standard payment item, with three prices, two actives"""
     item = PaymentItem()
+    item.event_id = event.id
     item.title = "Repas"
-    item.prices = [regular_price(), leader_price(), disabled_price()]
+    item.prices = [regular_price(), leader_price(item), disabled_price()]
 
     return item
 

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -1,9 +1,6 @@
-import unittest
-import datetime
-from os import environ
-from io import StringIO
+""" Unit tests for Event class """
 
-import flask_testing
+import datetime
 
 # pylint: disable=C0301
 from collectives.models import db, ActivityType, Event

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -1,0 +1,129 @@
+import unittest
+import datetime
+from os import environ
+from io import StringIO
+
+import flask_testing
+
+# pylint: disable=C0301
+from collectives.models import db, ActivityType, Event
+from collectives.models import Registration, RegistrationLevels, RegistrationStatus
+
+from tests.fixtures.user import promote_to_leader
+
+
+def test_event_validity(event1, user1, user2):
+    """Test event validity checks"""
+    activity1 = ActivityType.query.get(1)
+    activity2 = ActivityType.query.get(2)
+
+    promote_to_leader(user1, activity=activity1.name)
+    promote_to_leader(user2, activity=activity2.name)
+
+    event = event1
+    event.activity_types.clear()
+    # Event has no activity, not valid
+    assert not event.is_valid()
+
+    # Test leaders
+    event.activity_types.append(activity1)
+    assert not event.has_valid_leaders()
+    event.leaders.append(user1)
+    assert event.has_valid_leaders()
+
+    event.activity_types.append(activity2)
+    assert not event.has_valid_leaders()
+    event.leaders.append(user2)
+    assert event.has_valid_leaders()
+
+    assert event.is_valid()
+
+    # Test slots
+    event.num_slots = 0
+    event.num_online_slots = 1
+    assert not event.is_valid()
+    event.num_online_slots = 0
+    assert event.is_valid()
+    event.num_slots = -1
+    assert not event.is_valid()
+    event.num_slots = 0
+    assert event.is_valid()
+
+    # Test dates
+    event.end = datetime.datetime.now()
+    assert not event.is_valid()
+    event.end = event.start
+    assert event.is_valid()
+
+    event.num_online_slots = 1
+    event.registration_open_time = datetime.datetime.now()
+    event.registration_close_time = datetime.datetime.now() + datetime.timedelta(days=1)
+
+    assert event.is_registration_open_at_time(datetime.datetime.now())
+
+    event.registration_open_time = event.registration_close_time + datetime.timedelta(
+        hours=1
+    )
+    assert not event.opens_before_closes()
+    assert not event.is_valid()
+
+    event.registration_open_time = datetime.datetime.combine(
+        event.end, datetime.datetime.min.time()
+    ) + datetime.timedelta(days=1)
+    event.registration_close_time = event.registration_open_time + datetime.timedelta(
+        hours=1
+    )
+    assert event.opens_before_closes()
+    assert not event.opens_before_ends()
+    assert not event.is_valid()
+
+    assert not event.is_registration_open_at_time(datetime.datetime.now())
+
+
+def test_add_registration(event1, user1, user2):
+    """Test registering users to an event"""
+
+    def make_registration(user):
+        """Utility func to create a registration for the given user"""
+        datetime.datetime.timestamp(datetime.datetime.now())
+        return Registration(
+            user=user, status=RegistrationStatus.Active, level=RegistrationLevels.Normal
+        )
+
+    event = event1
+    event.num_online_slots = 2
+    event.registration_open_time = datetime.datetime.now()
+    event.registration_close_time = datetime.datetime.now() + datetime.timedelta(days=1)
+
+    db.session.add(event)
+    db.session.commit()
+
+    now = datetime.datetime.now()
+    assert event.is_registration_open_at_time(now)
+    assert event.has_free_online_slots()
+
+    assert event.can_self_register(user1, now)
+    assert event.can_self_register(user2, now)
+
+    event.registrations.append(make_registration(user1))
+    db.session.commit()
+    assert not event.can_self_register(user1, now)
+    assert event.can_self_register(user2, now)
+
+    event.num_online_slots = 1
+
+    assert not event.has_free_online_slots()
+    assert not event.can_self_register(user2, now)
+
+    event.registrations[0].status = RegistrationStatus.Rejected
+    assert event.has_free_online_slots()
+    assert not event.can_self_register(user1, now)
+    assert event.can_self_register(user2, now)
+
+    db.session.commit()
+
+    # Test db has been updated
+    db_event = Event.query.filter_by(id=event.id).first()
+    assert db_event.has_free_online_slots()
+    assert not db_event.can_self_register(user1, now)
+    assert db_event.can_self_register(user2, now)

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -1,3 +1,5 @@
+"""Unit tests for Role class"""
+
 from collectives.models.role import RoleIds, Role
 from collectives.models.user import User, activity_supervisors
 from collectives.models.activity_type import ActivityType
@@ -13,8 +15,6 @@ def test_add_role(user1):
 
     db.session.add(user1)
     db.session.commit()
-
-    assert admin_role in db.session
 
     retrieved_user = User.query.filter_by(id=user1.id).first()
     assert len(retrieved_user.roles) == 1

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -1,0 +1,50 @@
+from collectives.models.role import RoleIds, Role
+from collectives.models.user import User, activity_supervisors
+from collectives.models.activity_type import ActivityType
+from collectives.models import db
+
+from tests.fixtures.user import promote_to_leader, promote_user
+
+
+def test_add_role(user1):
+    """Test adding a general role to an user"""
+    admin_role = Role(role_id=int(RoleIds.Administrator))
+    user1.roles.append(admin_role)
+
+    db.session.add(user1)
+    db.session.commit()
+
+    assert admin_role in db.session
+
+    retrieved_user = User.query.filter_by(id=user1.id).first()
+    assert len(retrieved_user.roles) == 1
+    assert retrieved_user.is_admin()
+    assert retrieved_user.is_moderator()
+    assert not retrieved_user.can_lead_activity(0)
+
+
+def test_add_activity_role(user2):
+    """Test adding an activity-specific role to an user"""
+
+    activity1 = ActivityType.query.get(1)
+    activity2 = ActivityType.query.get(2)
+
+    promote_to_leader(user2, activity=activity1.name)
+
+    retrieved_user = User.query.filter_by(id=user2.id).first()
+    assert len(retrieved_user.roles) == 1
+    assert not retrieved_user.is_admin()
+    assert not retrieved_user.is_moderator()
+    assert retrieved_user.can_lead_activity(activity1.id)
+    assert not retrieved_user.can_lead_activity(activity2.id)
+
+    promote_user(
+        user2, activity_name=activity2.name, role_id=RoleIds.ActivitySupervisor
+    )
+
+    supervisors = activity_supervisors([activity1])
+    assert len(supervisors) == 0
+    supervisors = activity_supervisors([activity2])
+    assert len(supervisors) == 1
+    supervisors = activity_supervisors([activity1, activity2])
+    assert len(supervisors) == 1

--- a/tests/unit/test_user_group.py
+++ b/tests/unit/test_user_group.py
@@ -1,8 +1,14 @@
-from tokenize import group
-from collectives.models.user_group import *
-from collectives.models.user import User
+"""Unit tests for UserGroup class"""
 
+from collectives.models.user_group import (
+    UserGroup,
+    GroupEventCondition,
+    GroupLicenseCondition,
+    GroupRoleCondition,
+)
+from collectives.models import db, RoleIds
 
+# pylint: disable=R0915
 def test_user_group_members(
     event1_with_reg, user1, president_user, admin_user, supervisor_user
 ):

--- a/tests/unit/test_user_group.py
+++ b/tests/unit/test_user_group.py
@@ -1,0 +1,112 @@
+from tokenize import group
+from collectives.models.user_group import *
+from collectives.models.user import User
+
+
+def test_user_group_members(
+    event1_with_reg, user1, president_user, admin_user, supervisor_user
+):
+    """Test listing user group members"""
+
+    group0 = UserGroup()
+
+    # Test event conditions
+    gec = GroupEventCondition(event_id=event1_with_reg.id)
+    db.session.add(gec)
+
+    group0.event_conditions.append(gec)
+    db.session.add(group0)
+    db.session.commit()
+
+    group0_members = group0.get_members()
+    assert len(group0_members) == 5
+    assert user1 in group0_members
+    assert admin_user in group0_members
+    assert president_user not in group0_members
+
+    gec.is_leader = False
+    db.session.add(gec)
+    db.session.commit()
+
+    group0_members = group0.get_members()
+    assert len(group0_members) == 4
+    assert user1 in group0_members
+    assert admin_user not in group0_members
+
+    gec.is_leader = None
+    db.session.add(gec)
+    db.session.commit()
+
+    group0.event_conditions.clear()
+    db.session.delete(gec)
+    db.session.commit()
+
+    # Test role conditions
+    grc1 = GroupRoleCondition(role_id=RoleIds.President)
+    grc2 = GroupRoleCondition(
+        role_id=RoleIds.ActivitySupervisor,
+        activity_id=supervisor_user.get_supervised_activities()[0].id,
+    )
+    group0.role_conditions.append(grc1)
+    group0.role_conditions.append(grc2)
+
+    db.session.add(group0)
+    db.session.commit()
+
+    group0_members = group0.get_members()
+    assert len(group0_members) == 2
+    assert supervisor_user in group0_members
+    assert president_user in group0_members
+    assert admin_user not in group0_members
+
+    grc2.activity_id += 1
+    db.session.add(grc2)
+    db.session.commit()
+
+    group0_members = group0.get_members()
+    assert len(group0_members) == 1
+    assert supervisor_user not in group0_members
+    assert president_user in group0_members
+
+    group0.role_conditions.clear()
+    db.session.delete(grc1)
+    db.session.delete(grc2)
+    db.session.commit()
+
+    # Test license conditions
+    user1.license_category = "J1"
+    president_user.license_category = "J2"
+
+    glc1 = GroupLicenseCondition(license_category="J1")
+    glc2 = GroupLicenseCondition(license_category="J2")
+    group0.license_conditions.append(glc1)
+    group0.license_conditions.append(glc2)
+
+    db.session.add(group0)
+    db.session.add(user1)
+    db.session.add(president_user)
+    db.session.commit()
+
+    group0_members = group0.get_members()
+    assert len(group0_members) == 2
+    assert supervisor_user not in group0_members
+    assert president_user in group0_members
+    assert user1 in group0_members
+
+    # Test combination
+    grc1 = GroupRoleCondition(role_id=RoleIds.President)
+    group0.role_conditions.append(grc1)
+    db.session.add(group0)
+    db.session.commit()
+
+    group0_members = group0.get_members()
+    assert len(group0_members) == 1
+    assert president_user in group0_members
+
+    gec = GroupEventCondition(event_id=event1_with_reg.id)
+    group0.event_conditions.append(gec)
+    db.session.add(group0)
+    db.session.commit()
+
+    group0_members = group0.get_members()
+    assert len(group0_members) == 0

--- a/tests/unit/utils/test_autocomplete.py
+++ b/tests/unit/utils/test_autocomplete.py
@@ -1,3 +1,5 @@
+"""Unit tests for user name auto-completion"""
+
 from collectives.api.autocomplete_user import find_users_by_fuzzy_name
 
 from collectives.models import db

--- a/tests/unit/utils/test_autocomplete.py
+++ b/tests/unit/utils/test_autocomplete.py
@@ -1,0 +1,27 @@
+from collectives.api.autocomplete_user import find_users_by_fuzzy_name
+
+from collectives.models import db
+
+
+def test_autocomplete(user1, user2):
+    """Test fuzzy user name matching"""
+    user1.first_name = "First"
+    user1.last_name = "User"
+
+    user2.first_name = "Second"
+    user2.last_name = "User"
+
+    db.session.add(user1)
+    db.session.add(user2)
+    db.session.commit()
+
+    users = list(find_users_by_fuzzy_name("user"))
+    assert len(users) == 2
+    users = list(find_users_by_fuzzy_name("rst u"))
+    assert len(users) == 1
+    assert users[0].mail == "user1@example.org"
+    users = list(find_users_by_fuzzy_name("sec"))
+    assert len(users) == 1
+    assert users[0].mail == "user2@example.org"
+    users = list(find_users_by_fuzzy_name("z"))
+    assert len(users) == 0

--- a/tests/unit/utils/test_import_csv.py
+++ b/tests/unit/utils/test_import_csv.py
@@ -1,3 +1,5 @@
+"""Unit tests for CSV import"""
+
 from io import StringIO
 import datetime
 
@@ -8,9 +10,9 @@ def test_csv_import(user1):
     """Test importing an event CSV file"""
 
     # pylint: disable=C0301
-    CSV = f""",,,,,,,,,,,,,,,\nMr TEST,{user1.license},26/11/2021 7:00,26/11/2021 7:00,Aiguille des Calvaires,Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,"""
+    csv = f""",,,,,,,,,,,,,,,\nMr TEST,{user1.license},26/11/2021 7:00,26/11/2021 7:00,Aiguille des Calvaires,Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,"""
 
-    output = StringIO(CSV)
+    output = StringIO(csv)
     events, processed, failed = csv_to_events(
         output, "{altitude}m-{denivele}m-{cotation}"
     )

--- a/tests/unit/utils/test_import_csv.py
+++ b/tests/unit/utils/test_import_csv.py
@@ -1,0 +1,27 @@
+from io import StringIO
+import datetime
+
+from collectives.utils.csv import csv_to_events
+
+
+def test_csv_import(user1):
+    """Test importing an event CSV file"""
+
+    # pylint: disable=C0301
+    CSV = f""",,,,,,,,,,,,,,,\nMr TEST,{user1.license},26/11/2021 7:00,26/11/2021 7:00,Aiguille des Calvaires,Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,"""
+
+    output = StringIO(CSV)
+    events, processed, failed = csv_to_events(
+        output, "{altitude}m-{denivele}m-{cotation}"
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert processed == 1
+    assert not failed
+    assert event.title == "Aiguille des Calvaires"
+    assert event.num_slots == 8
+    assert event.num_online_slots == 4
+    assert event.registration_open_time == datetime.datetime(2021, 11, 19, 7, 0, 0)
+    assert event.registration_close_time == datetime.datetime(2021, 11, 25, 12, 0, 0)
+    assert "2322m-1200m-F" in event.rendered_description
+    assert event.leaders[0].license == user1.license


### PR DESCRIPTION
Pas mal de tickets visent à avoir des restrictions plus avancées pour les events et tarifs.
Cette PR vise à préparer les bases pour cela en remplacant les restrictions actuelles (parent_event, is_leader, etc) par le concept de "groupe d'utilisateur" défini par des règles dynamiques (inscription à un ou plusieurs événements, role, licence, etc)

Pour l'instant ces nouvelles fonctionnalités ne sont pas exposées; l'interface reste exactement la même. En revanche, le code migre de l'ancienne représentation (parent_event, is_leader) vers la nouvelle basée sur les groupes. 
Cette migration n'est pas faite au niveau de Flask-Migrate (cela serait fragile si les modèles changent avant que la migration ne soit effectuée), mais au fur et à mesure:
 - tous les nouveaux éléments utilisent la nouvelle structure
 - les éléments existants sont migrés au premier accès

