### PR TITLE
[INTERNAL] Fix db migration tests

### DIFF
--- a/.github/workflows/db_migrations.yml
+++ b/.github/workflows/db_migrations.yml
@@ -52,7 +52,7 @@ jobs:
       uses: ankane/setup-mariadb@v1
       with:
         database: ${{ env.DB_DATABASE }}
-        mariadb-version: "10.5"
+        mariadb-version: "10.8"
     - name: Load migrations on MariaDB
       env:
         FLASK_APP: collectives:create_app


### PR DESCRIPTION
Fix github test: mariadb 10.5 is not available on jammy. Bump to 10.8