### PR TITLE
FIX-Issue-604-Waiting_list_badge

### DIFF
--- a/collectives/api/event.py
+++ b/collectives/api/event.py
@@ -179,9 +179,7 @@ class EventSchema(marshmallow.Schema):
     """ Tags this event.
 
      :type: :py:class:`marshmallow.fields.Function`"""
-    has_free_online_slots = fields.Function(
-        lambda event: event.has_free_online_slots()
-    )
+    has_free_online_slots = fields.Function(lambda event: event.has_free_online_slots())
     """ Tags this event.
 
     :type: :py:class:`marshmallow.fields.Function`"""

--- a/collectives/api/event.py
+++ b/collectives/api/event.py
@@ -178,6 +178,12 @@ class EventSchema(marshmallow.Schema):
     )
     """ Tags this event.
 
+     :type: :py:class:`marshmallow.fields.Function`"""
+    has_free_online_slots = fields.Function(
+        lambda event: event.has_free_online_slots()
+    )
+    """ Tags this event.
+
     :type: :py:class:`marshmallow.fields.Function`"""
 
     class Meta:
@@ -204,6 +210,7 @@ class EventSchema(marshmallow.Schema):
             "tags",
             "has_free_slots",
             "has_free_waiting_slots",
+            "has_free_online_slots",
         )
 
 

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -166,9 +166,9 @@ function eventRowFormatter(row){
 }
 
 function getSlotsAvailableBadge(event) {
-    "returns 'Full' badge when no more available slots, and 'waiting list' when main list is full, but there are still availabilities in waiting list"
+    "returns 'Full' badge when no more available slots, and 'waiting list' when there are availabilities in waiting list (whatever is the number of already registered participants)"
     if (event.status != EnumEventStatus['Cancelled'])
-        if (!event.has_free_slots && event.has_free_waiting_slots)
+        if (event.has_free_waiting_slots)
             return `<span class="event-status-badge event-status-waiting-list ">Liste d'attente</span>`
         else if (!event.has_free_slots && !event.has_free_waiting_slots)
             return `<span class="event-status-badge event-status-full ">Complet</span>`

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -166,9 +166,9 @@ function eventRowFormatter(row){
 }
 
 function getSlotsAvailableBadge(event) {
-    "returns 'Full' badge when no more available slots, and 'waiting list' when there are availabilities in waiting list (whatever is the number of already registered participants)"
+    "returns 'Full' badge when no more available slots, and 'waiting list' when there are availabilities in waiting list (whatever is the number of already registered"
     if (event.status != EnumEventStatus['Cancelled'])
-        if (event.has_free_waiting_slots)
+        if (event.has_free_waiting_slots && (!event.has_free_online_slots))
             return `<span class="event-status-badge event-status-waiting-list ">Liste d'attente</span>`
         else if (!event.has_free_slots && !event.has_free_waiting_slots)
             return `<span class="event-status-badge event-status-full ">Complet</span>`


### PR DESCRIPTION
Fix cette issue: [Issue 604](https://github.com/Club-Alpin-Annecy/collectives/issues/604)

**NB: les règles implémentées sont:**

1. Le badge "liste d'attente" s'affiche si:

- Si aucun slot online n'est dispo mais qu'il y a des slots sur waiting_list
- si plus de slots dispo mais qu'il reste des slots en waiting_list

2. Le badge "liste d'attente" ne s'affiche pas" si:

- il reste des slots online dispos (même s'il y a des slots sur waiting_list)