### PR TITLE
[FEATURE] Preserve data, title, leader filter for duration of session

### DIFF
--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -77,15 +77,21 @@ function buildEventsTable() {
 
     var newSession = true;
     try {
-        if(sessionStorage.getItem("eventlist-sessionInitialized"))
-        {
-            newSession = false;
+        var currentTime = new Date();
+        var sessionTime = sessionStorage.getItem("eventlist-sessionDate");
+        if (sessionTime) {
+            var elapsedMilliseconds = currentTime - Date.parse(sessionTime)
+            if(elapsedMilliseconds < 86400 * 1000)
+            {
+                // Last seen less that a day ago, keep session filters
+                newSession = false;
+            }
         }
-        sessionStorage.setItem("eventlist-sessionInitialized", true)
+        sessionStorage.setItem("eventlist-sessionDate", currentTime)
     } catch(error) {}
 
     if(newSession) {
-        // Don't keep stored filters about leader, start and title
+        // Don't keep stored filters about leader, date and title
         // between browser sessions
         removeFilter(eventsTable, 'leaders');
         removeFilter(eventsTable, 'start');
@@ -272,7 +278,7 @@ function refreshFilterDisplay(){
             document.getElementById('select_event_type_'+filter['value']).checked = true;
         if (filter['field'] == 'tags')
             document.getElementById('select_tag_'+filter['value']).checked = true;
-        if (filter['field'] == 'start') {
+        if (filter['field'] == 'end') {
             document.querySelector('#datefilter').value = filter['value'];
         }
         if (filter['field'] == 'title') {

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -40,7 +40,6 @@ function buildEventsTable() {
         pageLoaded :  updatePageURL,
 
         initialSort: [ {column:"start", dir:"asc"}],
-        initialFilter: [{field:"end", type:">=", value:"now" }],
         columns:[
             {title:"Titre", field:"title", sorter:"string"},
             {title:"Date", field:"start", sorter:"string"},
@@ -76,11 +75,25 @@ function buildEventsTable() {
         },
     });
 
-    // Don't keep stored filters about leader, start, end and title
-    removeFilter(eventsTable, 'leaders');
-    removeFilter(eventsTable, 'start');
-    removeFilter(eventsTable, 'end');
-    removeFilter(eventsTable, 'title');
+    var newSession = true;
+    try {
+        if(sessionStorage.getItem("eventlist-sessionInitialized"))
+        {
+            newSession = false;
+        }
+        sessionStorage.setItem("eventlist-sessionInitialized", true)
+    } catch(error) {}
+
+    if(newSession) {
+        // Don't keep stored filters about leader, start and title
+        // between browser sessions
+        removeFilter(eventsTable, 'leaders');
+        removeFilter(eventsTable, 'start');
+        removeFilter(eventsTable, 'end');
+        removeFilter(eventsTable, 'title');
+
+        document.querySelector('#datefilter').value = moment().format("MM/DD/YYYY");
+    }
 
    document.querySelectorAll('.tabulator-paginator button').forEach(function(button){
        button.addEventListener('click', gotoEvents);
@@ -102,13 +115,10 @@ function buildEventsTable() {
        console.log('No page defined');
    }
 
-   document.querySelector('#datefilter').value = moment().format("MM/DD/YYYY");
    var tailOpts = {locale: "fr", dateFormat: "dd/mm/YYYY", timeFormat: false,};
    tail.DateTime(document.querySelector('#datefilter'), tailOpts);
 
    refreshFilterDisplay();
-
-
 }
 
 function eventRowFormatter(row){
@@ -262,6 +272,15 @@ function refreshFilterDisplay(){
             document.getElementById('select_event_type_'+filter['value']).checked = true;
         if (filter['field'] == 'tags')
             document.getElementById('select_tag_'+filter['value']).checked = true;
+        if (filter['field'] == 'start') {
+            document.querySelector('#datefilter').value = filter['value'];
+        }
+        if (filter['field'] == 'title') {
+            return document.querySelector('#title').value = filter['value'];
+        }
+        if (filter['field'] == 'leaders') {
+            return document.querySelector('#leader').value = filter['value'];
+        }
     }
 
 


### PR DESCRIPTION
https://trello.com/c/VxhjzM7X/284-garder-tous-les-filtres-de-la-liste-d%C3%A9v%C3%A9nement-en-m%C3%A9moire

En gros des utilisateurs se plaignaient que lorsqu'ils revenaient à la liste des collectives, certains filtres étaient perdus. En revanche ça n'aurait pas de sens de persister le filtre de date (par ex.) sur du long terme, du coup maintenant les filtres sont gardés tant que la session du navigateur est ouverte ET que la page a été rechargée depuis moins d'un jour 

@jnguiot du coup j'ai changé le "start" en "end" comme dans ta PR, c'est cassé pour l'instant en attendant que #634 soit mergée 