### PR TITLE
[ADD] Split de la colonne "Nom" de l'export des participants d'une collective en "Prénom" et "Nom" (uppercase)

### DIFF
--- a/collectives/utils/export.py
+++ b/collectives/utils/export.py
@@ -91,6 +91,7 @@ def export_users_registered(event):
     worksheet = workbook.active
     fields = [
         "Licence",
+        "Prénom",
         "Nom",
         "Téléphone",
         "Email",
@@ -101,7 +102,8 @@ def export_users_registered(event):
     for reg in event.active_registrations():
         temp = [
             reg.user.license,
-            reg.user.full_name(),
+            reg.user.first_name,
+            reg.user.last_name.upper(),
             reg.user.phone,
             reg.user.mail,
             f"{ reg.user.emergency_contact_name } ({ reg.user.emergency_contact_phone })",

--- a/tests/events/test_event.py
+++ b/tests/events/test_event.py
@@ -219,11 +219,12 @@ def test_event_export_list(leader_client, event1_with_reg, user2):
     workbook = load_workbook(filename=BytesIO(response.data))
     worksheet = workbook.active
     assert worksheet.max_row == 5
-    assert worksheet.max_column == 5
+    assert worksheet.max_column == 6
     assert worksheet["A3"].value == user2.license
-    assert worksheet["B3"].value == user2.full_name()
-    assert worksheet["C3"].value == user2.phone
-    assert worksheet["D3"].value == user2.mail
+    assert worksheet["B3"].value == user2.first_name
+    assert worksheet["C3"].value == user2.last_name.upper()
+    assert worksheet["D3"].value == user2.phone
+    assert worksheet["E3"].value == user2.mail
 
 
 def test_event_print(leader_client, event1_with_reg, user2):


### PR DESCRIPTION
Rien à ajouter, quick