### PR TITLE
[FIX] Unregister from waiting list should not block registering on other events

### DIFF
--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -882,8 +882,12 @@ def self_unregister(event_id):
         return redirect(url_for("event.view_event", event_id=event_id))
 
     previous_status = registration.status
-    registration.status = RegistrationStatus.SelfUnregistered
-    db.session.add(registration)
+    if registration.status == RegistrationStatus.Waiting:
+        db.session.delete(registration)
+    else:
+        registration.status = RegistrationStatus.SelfUnregistered
+        db.session.add(registration)
+
     update_waiting_list(event)
     db.session.commit()
 

--- a/collectives/templates/event/editevent.html
+++ b/collectives/templates/event/editevent.html
@@ -189,7 +189,10 @@
         <label for="num_online_slots">Nombre de participants internet : </label> {{ form.num_online_slots(size=4) }}
       </div>
       <div class="controls">
-        <label for="num_waiting_list">Nombre de places en liste d'attente : </label> {{ form.num_waiting_list(size=4) }}
+        <label for="num_waiting_list">Nombre de places en liste d'attente : 
+          <span class="label-help">&#9432; Inscription automatique avant la date de fin d'inscription, manuellement ensuite.</span> 
+        </label> 
+        {{ form.num_waiting_list(size=4) }}
       </div>
       <div class="controls">
         <div class="datetimepicker" id="datetimepicker_open"><label for="registration_open_time" >Ouverture des inscriptions : </label>{{ form.registration_open_time(onchange="checkDateOrder();")}}</div>

--- a/collectives/templates/partials/event/self_register.html
+++ b/collectives/templates/partials/event/self_register.html
@@ -35,7 +35,13 @@
                             />
                 <h1 class="heading-1">Confirmation {% if waiting_list %} d'inscription à la liste d'attente{% endif %}</h1>
                 {% if event.event_type.terms_file %}
-                <p>L'inscription à un événement vous engage à y participer.</p>
+                {% if waiting_list %}
+                    <p>L'inscription à la liste d'attente vous engage à y participer si vous êtes sélectionnés.</p>
+                    <p>Vous pourrez être sélectionnés automatiquement jusqu'à la fin de la période d'inscription si un participant 
+                        est désinscrit, puis manuellement par l'encadrant ensuite.</p>
+                {% else %}
+                    <p>L'inscription à un événement vous engage à y participer.</p>
+                {% endif %}
                 <p>
                     <label><input type="checkbox" required="required"/> J'ai lu et j'accepte le <a href="{{ url_for('static', filename='caf/doc/guide_collectives/'+event.event_type.terms_file) }}">{{event.event_type.terms_title}}</a></label><br/>
                 </p>

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -107,6 +107,14 @@ def user1_client(client, user1):
 
 
 @pytest.fixture
+def user3_client(client, user3):
+    """Flask client authenticated as regular user."""
+    login(client, user3)
+    yield client
+    logout(client)
+
+
+@pytest.fixture
 def leader_client(client, leader_user):
     """Flask client authenticated as regular user."""
     login(client, leader_user)

--- a/tests/fixtures/event.py
+++ b/tests/fixtures/event.py
@@ -187,13 +187,31 @@ def free_paying_event(prototype_free_paying_event):
 
 @pytest.fixture
 def event1_with_reg(event1, user1, user2, user3, user4):
-    """:returns: The fixture `event1`, with user registered.
+    """:returns: The fixture `event1`, with 4 users registered.
     :rtype: :py:class:`collectives.models.event.Event`"""
     for user in [user1, user2, user3, user4]:
         event1.registrations.append(
             Registration(
                 user_id=user.id,
                 status=RegistrationStatus.Active,
+                level=RegistrationLevels.Normal,
+                is_self=True,
+            )
+        )
+    return event1
+
+
+@pytest.fixture
+def event1_with_reg_waiting_list(event1, user1, user2, user3, user4):
+    """:returns: The fixture `event1`, with 4 users registered, and 2 in waiting_list.
+    :rtype: :py:class:`collectives.models.event.Event`"""
+    event1.num_online_slots = 2
+    for user in [(user1, True), (user2, True), (user3, False), (user4, False)]:
+        status = RegistrationStatus.Active if user[1] else RegistrationStatus.Waiting
+        event1.registrations.append(
+            Registration(
+                user_id=user[0].id,
+                status=status,
                 level=RegistrationLevels.Normal,
                 is_self=True,
             )


### PR DESCRIPTION
Petite modif du workflow des désinscriptions: une désinscription de la liste d'attente ne bloque plus les inscriptions à une autre collective.

J'en ai profité pour rajouter des tests