### PR TITLE
Fix waiting list updates for simultaneous registrations

### DIFF
--- a/collectives/configuration.yaml
+++ b/collectives/configuration.yaml
@@ -309,6 +309,14 @@ Mail:
         description: Email template content for a waiting user when his subscription is activated
         type: LongString
 
+    DELETED_REGISTRATIONS_POST_SCRIPTUM:
+        content: |
+            PS: Vous avez été automatiquement désinscrit(e) des collectives suivantes, 
+            se déroulant simultanément et pour lesquelles vous étiez également en liste d'attente :
+            {titles}
+        description: Email template post-scriptum for a waiting user when their registrations to other waiting lists are removed
+        type: LongString
+
 
 APPEARANCE:
     COVER_CREDIT:

--- a/collectives/models/event/payment.py
+++ b/collectives/models/event/payment.py
@@ -3,6 +3,8 @@
 from datetime import timedelta
 
 from collectives.models.registration import RegistrationStatus
+from collectives.models.user import User
+from collectives.utils.time import current_time
 
 
 class EventPaymentMixin:
@@ -71,3 +73,14 @@ class EventPaymentMixin:
                     time_shift, old_event_id=source_event.id, new_event_id=self.id
                 )
             )
+
+    def exist_available_prices_for_user(self, user: User) -> bool:
+        """:returns: whether there exist currently available prices for an user
+
+        :param user: The user for whom to check price availability
+        """
+        time = current_time()
+        return any(
+            item.available_prices_to_user_at_date(user, time)
+            for item in self.payment_items
+        )

--- a/collectives/models/user/role.py
+++ b/collectives/models/user/role.py
@@ -2,7 +2,6 @@
 
 from collectives.models.globals import db
 from collectives.models.activity_type import ActivityType
-from collectives.models.event import Event, EventType
 from collectives.models.role import RoleIds
 
 
@@ -243,6 +242,8 @@ class UserRoleMixin:
         :return: True if user can lead on the specified timespan.
         :rtype: boolean
         """
+        # pylint: disable=(import-outside-toplevel
+        from collectives.models.event import Event, EventType
 
         query = db.session.query(Event)
         query = query.filter(Event.start < end)

--- a/collectives/templates/partials/event/self_register.html
+++ b/collectives/templates/partials/event/self_register.html
@@ -36,9 +36,11 @@
                 <h1 class="heading-1">Confirmation {% if waiting_list %} d'inscription à la liste d'attente{% endif %}</h1>
                 {% if event.event_type.terms_file %}
                 {% if waiting_list %}
-                    <p>L'inscription à la liste d'attente vous engage à y participer si vous êtes sélectionnés.</p>
-                    <p>Vous pourrez être sélectionnés automatiquement jusqu'à la fin de la période d'inscription si un participant 
-                        est désinscrit, puis manuellement par l'encadrant ensuite.</p>
+                    <p>L'inscription à la liste d'attente vous engage à y participer si vous êtes sélectionné(e).</p>
+                    <p>Vous pourrez être sélectionné(e) automatiquement jusqu'à la fin de la période d'inscription si un participant
+                        est désinscrit, puis manuellement par l'encadrant ensuite. Il est possible de s'inscrire à plusieurs listes d'attentes simultanées ;
+                       si vous êtes sélectionné(e) pour l'une d'entre elles, les autres inscriptions seront automatiquement annulées.
+                    </p>
                 {% else %}
                     <p>L'inscription à un événement vous engage à y participer.</p>
                 {% endif %}

--- a/tests/fixtures/app.py
+++ b/tests/fixtures/app.py
@@ -29,7 +29,10 @@ def db_file():
 @pytest.fixture
 def app(db_file):
     """Session-wide test `Flask` application."""
-    extra_config = {"SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_file}"}
+    extra_config = {
+        "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_file}",
+        "SERVER_NAME": "localhost",
+    }
     fixture_app = collectives.create_app(
         "../tests/assets/config.test.py", extra_config=extra_config
     )


### PR DESCRIPTION
 - Skip users that have an active registration to another event
 - Skip users that would not be able to pay for the event
 - Delete other waiting registrations for simultaneous events