### PR TITLE
Restrict user profile access to leaders with event link

### DIFF
--- a/collectives/templates/event/editevent.html
+++ b/collectives/templates/event/editevent.html
@@ -132,9 +132,7 @@
         {% for action in form.leader_actions %}
           {% with user = form.current_leaders[loop.index0]%}
           <div class="useractionmenu">
-            {% with leader_info=True %}
-              {{ macros.usericon(user, leader_info, user_info) }}
-            {% endwith %}
+            {{ macros.leader_icon(user) }}
 
             <div class="inline_field">
               {{action.leader_id}}

--- a/collectives/templates/event/event.html
+++ b/collectives/templates/event/event.html
@@ -110,19 +110,14 @@
       <h3 class="heading-3">Encadrement</h3>
       <div class="userlist">
       {% for user in event.ranked_leaders() %}
-        {% with leader_info=True %}
-          {{ macros.usericon(user, leader_info, user_info) }}
-        {% endwith %}
+        {{ macros.leader_icon(user) }}
       {% endfor %}
 
       {% if event.coleaders() | length %}
         <h4 class="heading-4">Co-encadrants en formation</h4>
         {% for registration in event.coleaders() %}
           <div class="useractionmenu">
-            {% with user = registration.user, user_info = event.has_edit_rights(current_user) %}
-              {{ macros.usericon(user, leader_info, user_info) }}
-            {% endwith %}
-
+            {{ macros.registration_icon(registration) }}
             {% if event.has_edit_rights(current_user) %}
             <div class="popover">
               <form class="update" action="{{url_for('event.change_registration_level', reg_id=registration.id, reg_level=registration.level.Normal)}}" method="post" onclick="this.submit();">
@@ -161,9 +156,7 @@
 
       {% for registration in event.active_normal_registrations() %}
           <div class="useractionmenu">
-            {% with user = registration.user, user_info = event.has_edit_rights(current_user) %}
-              {{ macros.usericon(user, leader_info, user_info) }}
-            {% endwith %}
+            {{ macros.registration_icon(registration) }}
 
             {% if event.has_edit_rights(current_user) %}
             <div class="popover">
@@ -182,9 +175,7 @@
       {% if event.has_edit_rights(current_user) %}
         {% for registration in event.holding_slot_registrations() if registration.is_pending_renewal() and registration.status.is_valid() %}
             <div class="useractionmenu">
-              {% with user = registration.user, user_info = True, is_pending_renewal = True %}
-                {{ macros.usericon(user, leader_info, user_info, is_pending_renewal) }}
-              {% endwith %}
+            {{ macros.registration_icon(registration) }}
             </div>
         {% endfor %}
       {% endif %}
@@ -317,9 +308,7 @@
           <br/>
           {% for registration in event.waiting_registrations() %}
               <div class="useractionmenu">
-                {% with user = registration.user, user_info = event.has_edit_rights(current_user) %}
-                  {{ macros.usericon(user, leader_info, user_info) }}
-                {% endwith %}
+                {{ macros.registration_icon(registration) }}
               </div>
           {% endfor %}
         {% endif %}

--- a/collectives/templates/event/partials/admin.html
+++ b/collectives/templates/event/partials/admin.html
@@ -141,7 +141,7 @@
                 {% for registration in event.registrations %}
                 <tr>
                     <td>
-                        <a href="{{url_for('profile.show_user', user_id=registration.user.id)}}">
+                        <a href="{{url_for('profile.show_user', user_id=registration.user.id, event_id=registration.event.id)}}">
                             {{ registration.user.full_name() }}
                             {% if registration.is_pending_renewal() %}
                                 {% set ns.license_to_renew = True %}

--- a/collectives/templates/macros.html
+++ b/collectives/templates/macros.html
@@ -1,6 +1,6 @@
-{% macro usericon(user, leader_info=None, user_info=None, is_pending_renewal=False) -%}
+{% macro usericon(user, show_info=False, info_url=None, with_license_tags=False, is_pending_renewal=False) -%}
 <div class="usericon">
-      <a class="usericon-wrapper" href="{% if leader_info %}{{url_for('profile.show_leader', leader_id=user.id)}}{% elif user_info %}{{url_for('profile.show_user', user_id=user.id)}}{%else%}#{% endif %}"
+      <a class="usericon-wrapper" href="{%if show_info%}{{info_url}}{%else%}#{%endif%}"
                   alt="Avatar de {{user.abbrev_name()}}">
             <img class="usericon-avatar" src="{% if user.avatar
                         %}{{ url_for('images.crop', filename=user.avatar, width=80, height=80) }}{%
@@ -8,19 +8,19 @@
                         %}{{ url_for('static', filename='img/icon/ionicon/md-person.svg')   }}{%
                   endif %}" />
             <span class="usericon-name">
-                  {% if leader_info %}
-                        {{user.full_name().title()}}
-                  {% elif user_info %}
-                        {% if user.is_minor() %}
-                              <span class="license-tag minor">-18</span>
-                        {% elif user.is_youth() %}
-                              <span class="license-tag youth">-25</span>
-                        {% endif %}
-                        {% if is_pending_renewal %}
-                              <span class="license-tag pending-renewal">
-                                    <img src="{{url_for('static', filename='img/icon/ionicon/md-time-white.svg')}}">
-                                    Licence à renouveler
-                              </span>
+                  {% if show_info %}
+                        {% if with_license_tags %}
+                              {% if user.is_minor() %}
+                                    <span class="license-tag minor">-18</span>
+                              {% elif user.is_youth() %}
+                                    <span class="license-tag youth">-25</span>
+                              {% endif %}
+                              {% if is_pending_renewal %}
+                                    <span class="license-tag pending-renewal">
+                                          <img src="{{url_for('static', filename='img/icon/ionicon/md-time-white.svg')}}">
+                                          Licence à renouveler
+                                    </span>
+                              {% endif %}
                         {% endif %}
                         {{user.full_name().title()}}
                   {% else %}
@@ -31,9 +31,23 @@
 </div>
 {%- endmacro %}
 
+{% macro leader_icon(leader) -%}
+      {{usericon(leader, show_info=True, info_url=url_for("profile.show_leader", leader_id=leader.id))}}
+{%- endmacro%}
+
+{% macro registration_icon(registration) -%}
+      {{ usericon(
+            registration.user,
+            show_info=registration.event.has_edit_rights(current_user),
+            info_url=url_for("profile.show_user", user_id=registration.user.id, event_id=registration.event.id),
+            with_license_tags=True,
+            is_pending_renewal=registration.is_pending_renewal()
+      )}}
+{%- endmacro%}
+
 {% macro registration_admin_list_item(registration) -%}
 <li>
-      <a href="{{url_for('profile.show_user', user_id=registration.user.id)}}">{{registration.user.full_name()}}</a>
+      <a href="{{url_for('profile.show_user', user_id=registration.user.id, event_id=registration.event.id)}}">{{registration.user.full_name()}}</a>
 
       {% if registration.unsettled_payments() | length %}
         Paiements en cours:

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,5 +1,7 @@
 """ Module to test user profile pages. """
 
+from flask import url_for
+
 from tests import utils
 from tests.fixtures import client
 
@@ -17,14 +19,23 @@ def test_show_user_profile(user1_client):
     assert user.mail in response.text
 
 
-def test_show_user_profile_to_leader(leader_client, user1):
+def test_show_user_profile_to_leader_with_event(leader_client, event1_with_reg, user1):
     """Test leader access to a user profile."""
 
-    response = leader_client.get(f"profile/user/{user1.id}")
+    response = leader_client.get(
+        url_for("profile.show_user", user_id=user1.id, event_id=event1_with_reg.id)
+    )
     assert response.status_code == 200
     assert user1.full_name() in response.text
     assert user1.license in response.text
     assert user1.mail in response.text
+
+
+def test_do_not_show_user_profile_to_leader_without_event(leader_client, user2):
+    """Test user access to another user profile."""
+
+    response = leader_client.get(f"/profile/user/{user2.id}")
+    assert response.status_code == 302
 
 
 def test_do_not_show_user_profile_to_other(user1_client, user2):


### PR DESCRIPTION
RGPD: prevent leaders from accessing arbitrary profiles if the user is not registered to an event they're leading.
Admins, hotline and supervisor can still access all profiles.

+ cleanup `usericon` Jonja macro