### PR TITLE
[FEATURE] - Late Unregistrations Handling

### DIFF
--- a/collectives/configuration.yaml
+++ b/collectives/configuration.yaml
@@ -247,6 +247,110 @@ Mail:
         type: LongString
 
 
+    LATE_UNREGISTER_SUBJECT:
+        content: "Notification de désinscription tardive"
+        description: Email subject for user late self unregister
+        type: ShortString
+
+    LATE_UNREGISTER_MESSAGE:
+        content: |
+            Bonjour,
+
+            Vous venez de vous désinscrire tardivement à l'événement '{event_title}' auquel vous étiez tenu de participer.
+
+            Selon le code du CAF, sauf raison valable, vous êtes tenus de participer à l'évènement auquel vous êtes inscrit.
+            
+            Si vous avez une raison valable, merci de prévenir votre encadrant '{event_main_leader}'.
+
+            3 désinscriptions tardives résulteront en un ban et une impossibilité de s'inscrire à des futures collectives.
+
+            Lien vers l'événement :
+            {link}
+
+            Vous recevez cet e-mail en tant qu'adhérent inscrit à une activité.
+            Cet e-mail est envoyé par un automate, répondre à cet e-mail sera sans effet.
+        description: Email template content for late self unregistration to an event
+        type: LongString
+
+    LATE_UNREGISTER_FIRST_WARNING_SUBJECT:
+        content: "Notification de désinscription tardive, premier avertissement"
+        description: Email subject for user late self unregister first warning
+        type: ShortString
+
+    LATE_UNREGISTER_FIRST_WARNING_MESSAGE:
+        content: |
+            Bonjour,
+
+            Vous venez de vous désinscrire tardivement à l'événement '{event_title}'.
+
+            Attention nous vous rappelons qu’une inscription vous engage.
+
+            N’oubliez pas de prévenir votre encadrant bénévole '{event_main_leader}' car vous risquez de bouleverser le bon déroulement de la collective. 
+
+            Comme indiqué dans le Guides Collectives une nouvelle désinscription non anticipée ou une nouvelle absence non justifiée pourra entrainer une suspension temporaire de votre compte.
+
+            Lien vers l'événement :
+            {link}
+
+            Vous recevez cet e-mail en tant qu'adhérent inscrit à une activité.
+            Cet e-mail est envoyé par un automate, répondre à cet e-mail sera sans effet.
+        description: Email template content for late self unregistration to an event
+        type: LongString
+
+    LATE_UNREGISTER_SECOND_WARNING_SUBJECT:
+        content: "Notification de désinscription tardive, deuxième avertissement"
+        description: Email subject for user late self unregister second warning
+        type: ShortString
+
+    LATE_UNREGISTER_SECOND_WARNING_MESSAGE:
+        content: |
+            Bonjour,
+
+            Vous venez de vous désinscrire tardivement à l'événement '{event_title}'.
+
+            Attention nous vous rappelons qu’une inscription vous engage.
+
+            C’est la deuxième fois cette année que vous vous désinscrivez de manière tardive ou que vous oubliez de venir, ce qui peut pénaliser l’encadrant bénévole ainsi que le reste du groupe.
+            
+            Merci de prévenir votre encadrant bénévole '{event_main_leader}' car vous risquez de bouleverser le bon déroulement de la collective. 
+
+            Comme indiqué dans le Guides Collectives une nouvelle désinscription non anticipée ou une absence non justifiée entrainera une suspension temporaire de votre compte.
+
+            Lien vers l'événement :
+            {link}
+
+            Vous recevez cet e-mail en tant qu'adhérent inscrit à une activité.
+            Cet e-mail est envoyé par un automate, répondre à cet e-mail sera sans effet.
+        description: Email template content for late self unregistration to an event
+        type: LongString
+
+    LATE_UNREGISTER_ACCOUNT_SUSPENSION_SUBJECT:
+        content: "Notification de désinscription tardive, suspension de compte"
+        description: Email subject for user late self unregister account suspension
+        type: ShortString
+
+    LATE_UNREGISTER_ACCOUNT_SUSPENSION_MESSAGE:
+        content: |
+            Bonjour,
+
+            Vous venez de vous désinscrire tardivement à l'événement '{event_title}'.
+
+            Attention nous vous rappelons qu’une inscription vous engage.
+
+            Malgré nos rappels, c’est la troisième fois cette année que vous vous désinscrivez de manière tardive ou que vous n’êtes pas présent.
+            
+            Cela pénalise profondément le bon fonctionnement du Club et cela prive d’autres personnes de participer à nos activités.
+
+            Comme indiqué dans le Guides Collectives, votre accès au site des collectives va être suspendu pour les 4 prochaines semaines.
+
+            Lien vers l'événement :
+            {link}
+
+            Vous recevez cet e-mail en tant qu'adhérent inscrit à une activité.
+            Cet e-mail est envoyé par un automate, répondre à cet e-mail sera sans effet.
+        description: Email template content for late self unregistration to an event
+        type: LongString
+
     REJECTED_REGISTRATION_SUBJECT:
         content: "Refus d'insription à la collective {event_title}"
         description: Email subject for rejected registration to an event

--- a/collectives/email_templates.py
+++ b/collectives/email_templates.py
@@ -247,6 +247,8 @@ def send_update_waiting_list_notification(
     # pylint: disable=broad-except
     except BaseException as err:
         current_app.logger.error(f"Mailer error: {err}")
+
+
 def send_late_unregistration_notification(event, user):
     """
     Send a notification to the user who recently unregistered lately from an event.
@@ -297,6 +299,6 @@ def send_late_unregistration_notification(event, user):
             email=[user.mail],
             message=message,
         )
-
+    # pylint: disable=broad-except
     except BaseException as err:
         current_app.logger.error(f"Mailer error: {err}")

--- a/collectives/models/badge.py
+++ b/collectives/models/badge.py
@@ -13,10 +13,14 @@ class BadgeIds(ChoiceEnum):
     Benevole = 1
 
     FirstWarning = 2
-    """ User has been issued a first warning regarding late unregistrations and unjustified absences. """
+    """ User has been issued a first warning regarding 
+    late unregistrations and unjustified absences. 
+    """
 
     SecondWarning = 3
-    """ User has been issued a second warning regarding late unregistrations and unjustified absences. """
+    """ User has been issued a second warning regarding 
+    late unregistrations and unjustified absences. 
+    """
 
     Banned = 4
     """ User has been banned. """
@@ -30,9 +34,9 @@ class BadgeIds(ChoiceEnum):
         """
         return {
             cls.Benevole: "Bénévole",
-            cls.FirstWarning: "Premier avertissement sur les absences injustifiées et les désinscriptions tardives",
-            cls.SecondWarning: "Deuxième avertissement sur les absences injustifiées et les désinscriptions tardives",
-            cls.Banned: "Bannis pour trop d'absences injustifiées et de désinscriptions tardives",
+            cls.FirstWarning: "Désinscription Tardive - 1er avertissement",
+            cls.SecondWarning: "Désinscription Tardive - 2ème avertissement",
+            cls.Banned: "Désinscription Tardive - Banni",
         }
 
     def relates_to_activity(self) -> bool:

--- a/collectives/models/badge.py
+++ b/collectives/models/badge.py
@@ -12,6 +12,15 @@ class BadgeIds(ChoiceEnum):
     # pylint: disable=invalid-name
     Benevole = 1
 
+    FirstWarning = 2
+    """ User has been issued a first warning regarding late unregistrations and unjustified absences. """
+
+    SecondWarning = 3
+    """ User has been issued a second warning regarding late unregistrations and unjustified absences. """
+
+    Banned = 4
+    """ User has been banned. """
+
     @classmethod
     def display_names(cls):
         """Display name for all badges
@@ -21,6 +30,9 @@ class BadgeIds(ChoiceEnum):
         """
         return {
             cls.Benevole: "Bénévole",
+            cls.FirstWarning: "Premier avertissement sur les absences injustifiées et les désinscriptions tardives",
+            cls.SecondWarning: "Deuxième avertissement sur les absences injustifiées et les désinscriptions tardives",
+            cls.Banned: "Bannis pour trop d'absences injustifiées et de désinscriptions tardives",
         }
 
     def relates_to_activity(self) -> bool:

--- a/collectives/models/event/registration.py
+++ b/collectives/models/event/registration.py
@@ -1,5 +1,6 @@
 """ Module for all Event methods related to registration manipulation and check."""
 
+from datetime import datetime, timedelta
 from operator import attrgetter
 
 from collectives.models.registration import RegistrationLevels, RegistrationStatus
@@ -214,6 +215,26 @@ class EventRegistrationMixin:
         return self.is_registered_with_status(
             user, [RegistrationStatus.SelfUnregistered]
         )
+
+    def is_late_unregistered(self, user):
+        """Check if a user has unregistered lately this event.
+
+        :param user: User which will be tested.
+        :type user: :py:class:`collectives.models.user.User`
+        :return: True if user is registered with a ``late unregistered`` status
+        :rtype: boolean
+        """
+        return self.is_registered_with_status(
+            user, [RegistrationStatus.LateSelfUnregistered]
+        )
+
+    def starts_within_48_hours(self):
+        """Check if an event starts within 48h of current time.
+
+        :return: True if event starts within 48h of current time
+        :rtype: boolean
+        """
+        return self.starts < datetime.now() + timedelta(hours=48)
 
     def is_user_in_user_group(self, user: "collectives.models.user.User") -> bool:
         """Check if a user is part of the event user group

--- a/collectives/models/event/registration.py
+++ b/collectives/models/event/registration.py
@@ -234,7 +234,7 @@ class EventRegistrationMixin:
         :return: True if event starts within 48h of current time
         :rtype: boolean
         """
-        return self.starts < datetime.now() + timedelta(hours=48)
+        return self.start < datetime.now() + timedelta(hours=48)
 
     def is_banned(self, user):
         """Check if a user is banned on this event.
@@ -296,10 +296,10 @@ class EventRegistrationMixin:
             return False
         if not self.event_type.has_valid_license(user):
             return False
+        if user.has_a_valid_banned_badge():
+            return False
         if not waiting:
             return self.has_free_online_slots()
         if self.has_free_online_slots():
-            return False
-        if user.has_a_valid_banned_badge():
             return False
         return len(self.waiting_registrations()) < self.num_waiting_list

--- a/collectives/models/event/registration.py
+++ b/collectives/models/event/registration.py
@@ -236,6 +236,16 @@ class EventRegistrationMixin:
         """
         return self.starts < datetime.now() + timedelta(hours=48)
 
+    def is_banned(self, user):
+        """Check if a user is banned on this event.
+
+        :param user: User which will be tested.
+        :type user: :py:class:`collectives.models.user.User`
+        :return: True if user is banned
+        :rtype: boolean
+        """
+        return user.has_a_valid_banned_badge()
+
     def is_user_in_user_group(self, user: "collectives.models.user.User") -> bool:
         """Check if a user is part of the event user group
 
@@ -261,6 +271,7 @@ class EventRegistrationMixin:
           - there are available online slots
           - user is registered to the parent event if any
           - user license is compatible with event type
+          - user does not have a valid Banned badge
 
         :param user: User which will be tested.
         :type user: :py:class:`collectives.models.user.User`
@@ -288,5 +299,7 @@ class EventRegistrationMixin:
         if not waiting:
             return self.has_free_online_slots()
         if self.has_free_online_slots():
+            return False
+        if user.has_a_valid_banned_badge():
             return False
         return len(self.waiting_registrations()) < self.num_waiting_list

--- a/collectives/models/registration.py
+++ b/collectives/models/registration.py
@@ -128,6 +128,11 @@ class RegistrationStatus(ChoiceEnum):
                 cls.Active,
             ],
             cls.LateSelfUnregistered: [
+                re_register_status,
+                cls.Waiting,
+                cls.ToBeDeleted,
+                cls.JustifiedAbsentee,
+                cls.UnJustifiedAbsentee,
             ],
         }
 

--- a/collectives/models/registration.py
+++ b/collectives/models/registration.py
@@ -47,7 +47,7 @@ class RegistrationStatus(ChoiceEnum):
     """
     SelfUnregistered = 3
     """ User has self unregister to the event.
-
+    
     User should not be able to register again without leader help."""
 
     JustifiedAbsentee = 4
@@ -65,6 +65,9 @@ class RegistrationStatus(ChoiceEnum):
 
     Present = 7
     """ User has been present to the event. """
+
+    LateSelfUnregistered = 8
+    """ User has self unregister to the event, but late. """
     # pylint: enable=invalid-name
 
     @classmethod
@@ -78,6 +81,7 @@ class RegistrationStatus(ChoiceEnum):
             cls.Rejected: "Refusée",
             cls.PaymentPending: "Attente de Paiement",
             cls.SelfUnregistered: "Auto désinscrit",
+            cls.LateSelfUnregistered: "Auto désinscrit tardif",
             cls.JustifiedAbsentee: "Absent justifié",
             cls.UnJustifiedAbsentee: "Absent non justifié",
             cls.ToBeDeleted: "Effacer l'inscription",
@@ -122,6 +126,8 @@ class RegistrationStatus(ChoiceEnum):
                 cls.JustifiedAbsentee,
                 cls.Waiting,
                 cls.Active,
+            ],
+            cls.LateSelfUnregistered: [
             ],
         }
 
@@ -232,6 +238,13 @@ class Registration(db.Model):
         :return: Is :py:attr:`status` unregistered ?
         :rtype: boolean"""
         return self.status == RegistrationStatus.SelfUnregistered
+
+    def is_late_unregistered(self):
+        """Check if this registation is unregistered lately, ie less than 48h before the event.
+
+        :return: Is :py:attr:`status` late unregistered ?
+        :rtype: boolean"""
+        return self.status == RegistrationStatus.LateSelfUnregistered
 
     def is_pending_payment(self):
         """Check if this registation is pending payment.

--- a/collectives/models/user/badge.py
+++ b/collectives/models/user/badge.py
@@ -2,9 +2,9 @@
 
 from typing import List, Optional
 
-from datetime import date
+from datetime import date, timedelta
 from collectives.models.badge import Badge, BadgeIds
-
+from collectives.models import db
 
 class UserBadgeMixin:
     """Part of User related to badge.
@@ -71,3 +71,82 @@ class UserBadgeMixin:
         """
         badges = self.matching_badges([badge_id])
         return any(badge.activity_id == activity_id for badge in badges)
+
+    def assign_badge(self, badge_id: BadgeIds, expiration_date: date, activity_id: Optional[int] = None, level: Optional[int] = None):
+        """Assign a badge to the user.
+
+        :param badge_id: The ID of the badge to be assigned.
+        :param expiration_date: The date when the badge will expire.
+        :param activity_id: The ID of the activity onto which the badge should be applied.
+        """
+        badge = Badge(
+            user_id=self.id,
+            badge_id=badge_id,
+            expiration_date=expiration_date,
+            activity_id=activity_id,
+            level=level
+        )
+        try:
+            db.session.add(badge)
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            raise e
+
+    def update_badge(self, badge_id: BadgeIds, expiration_date: Optional[date] = None, 
+                    activity_id: Optional[int] = None, level: Optional[int] = None):
+        """Update a badge for the user.
+
+        :param badge_id: The ID of the badge to be updated.
+        :param expiration_date: The date when the badge will expire.
+        :param activity_id: The ID of the activity onto which the badge should be applied.
+        """
+        badge_data = {}
+        if expiration_date is not None:
+            badge_data["expiration_date"] = expiration_date
+        if activity_id is not None:
+            badge_data["activity_id"] = activity_id
+        if level is not None:
+            badge_data["level"] = level
+
+        Badge.query.filter_by(user_id=self.id, badge_id=badge_id).update(badge_data)
+        db.session.commit()
+
+    def remove_badge(self, badge_id: BadgeIds):
+        """Remove a badge from the user.
+
+        :param badge_id: The ID of the badge to be removed.
+        """
+        Badge.query.filter_by(user_id=self.id, badge_id=badge_id).delete()
+        db.session.commit()
+
+def update_warning_badges(self):
+    """
+    Update warning badges based on user's conditions and level, and assign or update the badge with appropriate expiration date and level.
+    """
+    # Check if user has a valid first warning badge
+    has_valid_first_warning_badge = self.has_a_valid_badge([BadgeIds.FirstWarning])
+    
+    # Check if user has a valid second warning badge
+    has_valid_second_warning_badge = self.has_a_valid_badge([BadgeIds.SecondWarning])
+
+
+    # Update badge and expiration date based on conditions
+    if has_valid_second_warning_badge:
+        badge_id = BadgeIds.Banned
+        expiration_date = date.today() + timedelta(months=1)
+    elif has_valid_first_warning_badge:
+        badge_id = BadgeIds.SecondWarning
+        expiration_date = date(date.today().year if date.today().month < 10 else date.today().year + 1, 9, 30)
+    else:
+        badge_id = BadgeIds.FirstWarning
+        expiration_date = date(date.today().year if date.today().month < 10 else date.today().year + 1, 9, 30)
+    
+    # Increment user's level
+    level = self.level + 1
+    
+    # Check if user already has the badge, if so, update it; if not, assign it
+    if self.has_badge([badge_id]):
+        self.update_badge(badge_id, expiration_date=expiration_date, level=level)
+    else:
+        self.assign_badge(badge_id, expiration_date=expiration_date, level=1)

--- a/collectives/models/user/badge.py
+++ b/collectives/models/user/badge.py
@@ -6,6 +6,7 @@ from datetime import date, timedelta
 from collectives.models.badge import Badge, BadgeIds
 from collectives.models import db
 
+
 class UserBadgeMixin:
     """Part of User related to badge.
 
@@ -48,6 +49,13 @@ class UserBadgeMixin:
         """
         return self.has_a_valid_badge([BadgeIds.Benevole])
 
+    def has_a_valid_banned_badge(self) -> bool:
+        """Check if user has a benevole badge.
+
+        :return: True if user has a non-expired banned badge.
+        """
+        return self.has_a_valid_badge([BadgeIds.Banned])
+
     def has_badge_for_activity(
         self, badge_ids: List[BadgeIds], activity_id: Optional[int]
     ) -> bool:
@@ -72,7 +80,13 @@ class UserBadgeMixin:
         badges = self.matching_badges([badge_id])
         return any(badge.activity_id == activity_id for badge in badges)
 
-    def assign_badge(self, badge_id: BadgeIds, expiration_date: date, activity_id: Optional[int] = None, level: Optional[int] = None):
+    def assign_badge(
+        self,
+        badge_id: BadgeIds,
+        expiration_date: date,
+        activity_id: Optional[int] = None,
+        level: Optional[int] = None,
+    ):
         """Assign a badge to the user.
 
         :param badge_id: The ID of the badge to be assigned.
@@ -84,7 +98,7 @@ class UserBadgeMixin:
             badge_id=badge_id,
             expiration_date=expiration_date,
             activity_id=activity_id,
-            level=level
+            level=level,
         )
         try:
             db.session.add(badge)
@@ -93,8 +107,13 @@ class UserBadgeMixin:
             db.session.rollback()
             raise e
 
-    def update_badge(self, badge_id: BadgeIds, expiration_date: Optional[date] = None, 
-                    activity_id: Optional[int] = None, level: Optional[int] = None):
+    def update_badge(
+        self,
+        badge_id: BadgeIds,
+        expiration_date: Optional[date] = None,
+        activity_id: Optional[int] = None,
+        level: Optional[int] = None,
+    ):
         """Update a badge for the user.
 
         :param badge_id: The ID of the badge to be updated.
@@ -120,33 +139,44 @@ class UserBadgeMixin:
         Badge.query.filter_by(user_id=self.id, badge_id=badge_id).delete()
         db.session.commit()
 
-def update_warning_badges(self):
-    """
-    Update warning badges based on user's conditions and level, and assign or update the badge with appropriate expiration date and level.
-    """
-    # Check if user has a valid first warning badge
-    has_valid_first_warning_badge = self.has_a_valid_badge([BadgeIds.FirstWarning])
-    
-    # Check if user has a valid second warning badge
-    has_valid_second_warning_badge = self.has_a_valid_badge([BadgeIds.SecondWarning])
+    def update_warning_badges(self):
+        """
+        Update warning badges based on user's conditions and level, 
+        and assign or update the badge with appropriate expiration date and level.
+        """
+        # Check if user has a valid first warning badge
+        has_valid_first_warning_badge = self.has_a_valid_badge([BadgeIds.FirstWarning])
 
+        # Check if user has a valid second warning badge
+        has_valid_second_warning_badge = self.has_a_valid_badge(
+            [BadgeIds.SecondWarning]
+        )
 
-    # Update badge and expiration date based on conditions
-    if has_valid_second_warning_badge:
-        badge_id = BadgeIds.Banned
-        expiration_date = date.today() + timedelta(months=1)
-    elif has_valid_first_warning_badge:
-        badge_id = BadgeIds.SecondWarning
-        expiration_date = date(date.today().year if date.today().month < 10 else date.today().year + 1, 9, 30)
-    else:
-        badge_id = BadgeIds.FirstWarning
-        expiration_date = date(date.today().year if date.today().month < 10 else date.today().year + 1, 9, 30)
-    
-    # Increment user's level
-    level = self.level + 1
-    
-    # Check if user already has the badge, if so, update it; if not, assign it
-    if self.has_badge([badge_id]):
-        self.update_badge(badge_id, expiration_date=expiration_date, level=level)
-    else:
-        self.assign_badge(badge_id, expiration_date=expiration_date, level=1)
+        # Update badge and expiration date based on conditions
+        if has_valid_second_warning_badge:
+            badge_id = BadgeIds.Banned
+            expiration_date = date.today() + timedelta(weeks=4)
+        elif has_valid_first_warning_badge:
+            badge_id = BadgeIds.SecondWarning
+            expiration_date = date(
+                date.today().year if date.today().month < 10 else date.today().year + 1,
+                9,
+                30,
+            )
+        else:
+            badge_id = BadgeIds.FirstWarning
+            expiration_date = date(
+                date.today().year if date.today().month < 10 else date.today().year + 1,
+                9,
+                30,
+            )
+
+        # Check if user already has the badge, if so, update it; if not, assign it
+        if self.has_badge([badge_id]):
+            # TODO: Update badge properly and leverage badges management utils ?
+            badge = self.matching_badges([badge_id])[0]
+            self.update_badge(
+                badge_id, expiration_date=expiration_date, level=badge.level + 1
+            )
+        else:
+            self.assign_badge(badge_id, expiration_date=expiration_date, level=1)

--- a/collectives/models/user/badge.py
+++ b/collectives/models/user/badge.py
@@ -141,7 +141,7 @@ class UserBadgeMixin:
 
     def update_warning_badges(self):
         """
-        Update warning badges based on user's conditions and level, 
+        Update warning badges based on user's conditions and level,
         and assign or update the badge with appropriate expiration date and level.
         """
         # Check if user has a valid first warning badge
@@ -172,11 +172,19 @@ class UserBadgeMixin:
             )
 
         # Check if user already has the badge, if so, update it; if not, assign it
-        if self.has_badge([badge_id]):
-            # TODO: Update badge properly and leverage badges management utils ?
-            badge = self.matching_badges([badge_id])[0]
-            self.update_badge(
-                badge_id, expiration_date=expiration_date, level=badge.level + 1
-            )
-        else:
-            self.assign_badge(badge_id, expiration_date=expiration_date, level=1)
+        try:
+            if self.has_badge([badge_id]):
+                existing_badges = self.matching_badges([badge_id])
+                if len(existing_badges) > 1:
+                    raise ValueError(f"More than one badge of type {badge_id} exists")
+
+                badge = existing_badges[0]
+                new_level = (1 if badge.level is None else badge.level) + 1
+                self.update_badge(
+                    badge_id, expiration_date=expiration_date, level=new_level
+                )
+            else:
+                self.assign_badge(badge_id, expiration_date=expiration_date, level=1)
+        except ValueError:
+            # Badges update should not break unregistration logic
+            pass

--- a/collectives/routes/administration.py
+++ b/collectives/routes/administration.py
@@ -4,6 +4,8 @@ All routes are protected by :py:fun:`before_request` which protect acces to admi
  """
 
 from datetime import date
+from sqlalchemy.orm import joinedload
+
 from flask import flash, render_template, redirect, url_for, send_file
 from flask import Blueprint
 from flask_login import current_user
@@ -308,10 +310,10 @@ def delete_user_badge(badge_id):
     :rtype: string
     """
 
-    badge = db.session.get(Badge, badge_id)
+    badge = db.session.query(Badge).options(joinedload(Badge.user)).get(badge_id)
 
     if badge is None:
-        flash("Badge inexistant", "error")
+        flash("Badge does not exist", "error")
         return redirect(url_for("administration.administration"))
 
     db.session.delete(badge)
@@ -321,7 +323,7 @@ def delete_user_badge(badge_id):
         "user_badges.html",
         user=badge.user,
         form=BadgeForm(),
-        title="Badges utilisateur",
+        title="User Badges",
         now=date.today(),
     )
 

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -5,6 +5,7 @@ This modules contains the /event Blueprint
 
 # pylint: disable=too-many-lines
 from typing import Tuple, List, Set
+from datetime import timedelta
 
 import builtins
 from flask import flash, render_template, redirect, url_for, request, send_file
@@ -20,6 +21,7 @@ from collectives.email_templates import send_unregister_notification
 from collectives.email_templates import send_reject_subscription_notification
 from collectives.email_templates import send_cancelled_event_notification
 from collectives.email_templates import send_update_waiting_list_notification
+from collectives.email_templates import send_late_unregistration_notification
 
 from collectives.forms import EventForm, photos
 from collectives.forms import RegistrationForm
@@ -34,6 +36,7 @@ from collectives.models.activity_type import activities_without_leader
 from collectives.models.activity_type import leaders_without_activities
 from collectives.models.payment import ItemPrice, Payment
 from collectives.models.question import QuestionAnswer
+from collectives.models.user.badge import update_warning_badges
 
 from collectives.utils.time import current_time
 from collectives.utils.url import slugify
@@ -890,6 +893,12 @@ def self_unregister(event_id):
     previous_status = registration.status
     if registration.status == RegistrationStatus.Waiting:
         db.session.delete(registration)
+    elif event.start < current_time() - timedelta(hours=48) and event.event_type.requires_activity:
+        registration.status = RegistrationStatus.LateSelfUnregistered
+        db.session.add(registration)
+        if previous_status == RegistrationStatus.Active:
+            update_warning_badges(current_user)
+            send_late_unregistration_notification(event, current_user)
     else:
         registration.status = RegistrationStatus.SelfUnregistered
         db.session.add(registration)

--- a/collectives/templates/event/event.html
+++ b/collectives/templates/event/event.html
@@ -3,6 +3,7 @@
 
 {% import 'macros.html' as macros with context %}
 {% import 'partials/event/self_register.html' as self_register with context %}
+{% import 'partials/event/self_unregister.html' as self_unregister with context %}
 
 
 {% block additionalhead %}
@@ -241,9 +242,15 @@
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
             <a  class="button button-secondary"
                 onclick="if(confirm(unregister_message{% if event.is_registered_with_status(current_user, [models.RegistrationStatus.Waiting]) %}_waiting{%endif%})) this.parentNode.submit()" >
-              <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-exit.svg') }}"/> Se désinscrire
+              <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-exit.svg') }}"/> Se désinscrire OLD
             </a>
-          </form><br/><br/>
+          </form>
+            {% if event.starts_within_48_hours %} {# Late Unregister #}          
+              {{ self_unregister.button(False) }}
+            {% else %}
+              {{ self_unregister.button() }}
+            {% endif %}
+          <br/><br/>
           {% endif %}
 
           {# Questionnaire #}

--- a/collectives/templates/event/event.html
+++ b/collectives/templates/event/event.html
@@ -206,6 +206,8 @@
           <p>Votre inscription a été refusée.</p>
         {% elif event.is_unregistered(current_user)%}
           <p>Vous vous êtes désincrit. Si vous souhaitez vous réinscrire, contactez l'encadrant.</p>
+        {% elif event.is_late_unregistered(current_user)%}
+          <p>Vous vous êtes désincrit tardivement. Si vous souhaitez vous réinscrire, contactez l'encadrant.</p>
         {% elif event.is_pending_payment(current_user) %}
           <p>Votre inscription est en attente de paiement.
           <ul>
@@ -238,16 +240,9 @@
           {% endif %}
 
           {% if current_time < event.start %} {# Unregister #}
-          <form action="{{url_for('event.self_unregister', event_id=event.id)}}" method="post"   class="selfunregister">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            <a  class="button button-secondary"
-                onclick="if(confirm(unregister_message{% if event.is_registered_with_status(current_user, [models.RegistrationStatus.Waiting]) %}_waiting{%endif%})) this.parentNode.submit()" >
-              <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-exit.svg') }}"/> Se désinscrire OLD
-            </a>
-          </form>
             {% if event.starts_within_48_hours %} {# Late Unregister #}          
               {{ self_unregister.button(False) }}
-            {% else %}
+            {% else %} {# Unregister #}
               {{ self_unregister.button() }}
             {% endif %}
           <br/><br/>
@@ -298,6 +293,9 @@
             {% endfor %}
           </ul></p>
           {% endif %}
+
+        {% elif event.is_banned(current_user) %}
+        <p>Vous êtes actuellement banni suite à un trop grand nombre de désinscriptions tardives. Vous pourrez vous ré-inscrire à nouveau 4 semaines après votre dernière désinscription tardive. Si vous pensez que c'est une erreur, merci de contacter un administrateur.</p>
 
         {% elif current_time > event.registration_close_time %}
         <p>Les inscriptions sont closes.</p>

--- a/collectives/templates/partials/event/self_unregister.html
+++ b/collectives/templates/partials/event/self_unregister.html
@@ -1,0 +1,44 @@
+{% macro button(within_limit = True) -%}
+
+    <form
+            action="{{url_for('event.self_unregister', event_id=event.id)}}"
+            method="post"
+
+        >
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+
+        <div
+                class="button button-secondary"
+                onclick= "this.nextSibling.nextSibling.style.display='block'"
+            >
+            <span class="name" ><img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-exit.svg') }}"/> Se désinscrire</span>
+        </div>
+
+        <div class="messages" style="display:none">
+            <div class="innermessages">
+                <img
+                                src="{{ url_for('static', filename='img/icon/ionicon/md-close-circle-outline.svg') }}"
+                                class="close"
+                                onclick= "this.parentNode.parentNode.style.display='none'"
+                            />
+                <h1 class="heading-1">Confirmation de désincription</h1>
+                {% if within_limit == False %}
+                    <p>Attention nous vous rappelons qu’une inscription vous engage.</p>
+                    <p>N’oubliez pas de prévenir l’encadrant bénévole car vous risquez de bouleverser le bon déroulement de la collective.</p>
+                    <p>Comme indiqué dans le Guides Collectives une nouvelle désinscription non anticipée pourra entrainer une suspension temporaire de votre compte.</p>
+                {% else %}
+                    <p>Comme indiqué dans le Guides Collectives, nous vous rappelons qu’une inscription vous engage.</p>
+                    <p>Dans la mesure du possible faites en sorte de vous inscrire, uniquement lorsque vous êtes sûr de pouvoir être présent.</p>
+                    <p>Si vous avez payé des frais, ceux-ci ne vous seront pas remboursés conformément aux CGU.</p>
+                {% endif %}
+                <h4 class="centeralign">Confirmez-vous votre désinscription ?<br/> 
+                    <input type="submit" id="submitSelfUnregister" value="Confirmer" class="button button-danger">
+                    <input type="button" id="cancelSelfUnregister" value="Annuler" class="button button-secondary" onclick="this.closest('.messages').style.display='none'">
+                </h4>
+            </div>
+            <div class="veil" onclick= "this.parentNode.style.display='none'"></div>
+        </div>
+
+    </form>
+
+{%- endmacro %}

--- a/collectives/templates/stats/partials/nb_unregistrations_inc_late_and_unjustified_absentees_per_week.html
+++ b/collectives/templates/stats/partials/nb_unregistrations_inc_late_and_unjustified_absentees_per_week.html
@@ -1,0 +1,54 @@
+<canvas id="unregistration-inc-late-and-unjustified-absentees-chart"></canvas>
+                
+<div class="tooltip">
+    <img src="{{ url_for('static', filename='img/icon/ionicon/md-information-circle-outline.svg') }}" alt="(I)" />
+    <span class="text">{{ engine.INDEX['nb_unregistrations_inc_late_and_unjustified_absentees_per_week']['description'] }}</span>
+</div>
+
+<script>
+  const unregistrationsData = {{ engine.nb_unregistrations_inc_late_and_unjustified_absentees_per_week() | tojson | safe }};
+  const labels = Object.keys(unregistrationsData);
+  const datasets = [];
+
+  const allStatuses = new Set();
+  Object.values(unregistrationsData).forEach(week => {
+    Object.keys(week).forEach(status => {
+      allStatuses.add(status);
+    });
+  });
+
+  allStatuses.forEach(status => {
+    const dataForStatus = labels.map(label => unregistrationsData[label][status] || 0);
+    datasets.push({
+      label: status,
+      data: dataForStatus,
+      fill: false,
+      tension: 0.1
+    });
+  });
+
+  new Chart(document.getElementById('unregistration-inc-late-and-unjustified-absentees-chart'), {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: datasets
+    },
+    options: {
+      plugins: {
+        legend: {
+          display: true,
+          position: 'top',
+        },
+        title: {
+          display: true,
+          text: "{{ engine.INDEX['nb_unregistrations_inc_late_and_unjustified_absentees_per_week']['name'] | safe }}",
+        }
+      },
+      scales: {
+        y: {
+          grace: "15%"
+        }
+      }
+    }
+  });
+</script>

--- a/collectives/templates/stats/stats.html
+++ b/collectives/templates/stats/stats.html
@@ -8,7 +8,7 @@
   <script>
     Chart.register(ChartDataLabels);
     Chart.defaults.set('plugins', {
-      datalabels: {font: {size: '30px'}, anchor: 'end', align : 'top'},
+      datalabels: {font: {size: '20px'}, anchor: 'end', align : 'top'},
       legend: { display: false },
       title: {
         display: true,
@@ -189,6 +189,19 @@
           </div> <!-- End .tile line -->
         {% endif %}
         <!-- End Leader section -->
+
+        <!-- Unregistration section -->
+        <div class="tile">
+          <div class="heading-2"><br/>Désinscriptions et Absences injustifiées</div>
+        </div>
+        <div class="tile">
+          <div class="tile is-parent">
+            <div class="tile card is-child tall">
+              {% include 'stats/partials/nb_unregistrations_inc_late_and_unjustified_absentees_per_week.html' %}
+            </div>
+          </div>
+        </div> <!-- End .tile line -->
+        <!-- End Unregistration section -->
 
       </div> <!-- End .tile .is-vertical -->
     </div> <!-- End .tile .is-ancestor -->

--- a/collectives/templates/user_badges.html
+++ b/collectives/templates/user_badges.html
@@ -5,7 +5,7 @@
 <div class="page-content" id="administration">
   <h2 class="heading-2">{{user.full_name()}}</h2>
 
-  <h4 class="heading-4">Badges existant</h4>
+  <h4 class="heading-4">Badges existants</h4>
   <ul>
   {% for badge in user.badges %}
   <li>{{badge.name}}

--- a/collectives/utils/stats.py
+++ b/collectives/utils/stats.py
@@ -454,7 +454,6 @@ class StatisticsEngine:
         counts = query.group_by(ActivityType.id).all()
         return {c[3].name: c[4] for c in counts}
 
-
     @lru_cache()
     def nb_unregistrations_inc_late_and_unjustified_absentees_per_week(self) -> dict:
         """
@@ -493,7 +492,6 @@ class StatisticsEngine:
             unregistrations_by_week_and_status[event_week][status_str] = count
 
         return unregistrations_by_week_and_status
-
 
     def export_excel(self) -> BytesIO:
         """Generate an Excel with all statistics inside.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,4 +9,5 @@ pytest_plugins = [
     "tests.fixtures.stats",
     "tests.mock.extranet",
     "tests.mock.payline",
+    "tests.mock.session",
 ]

--- a/tests/events/test_registrations.py
+++ b/tests/events/test_registrations.py
@@ -2,6 +2,7 @@
 
 from datetime import date, timedelta, datetime
 from collectives.models import db, RegistrationStatus, BadgeIds
+
 # pylint: disable=unused-argument
 
 
@@ -228,10 +229,10 @@ def test_youth_event_failed_autoregistration(user1, user1_client, youth_event):
 
 # Late unregistration-related tests
 def test_unregister_lately_no_warning(
-        client_with_no_warning_badge,
-        user_with_no_warning_badge,
-        event_in_less_than_48h_with_reg
-        ):
+    client_with_no_warning_badge,
+    user_with_no_warning_badge,
+    event_in_less_than_48h_with_reg,
+):
     """
     Tests the late self-unregistration of a user without any unregistration-related warning badge.
     Verifies that the user is correctly unregistered and that badges are assigned as expected.
@@ -249,11 +250,12 @@ def test_unregister_lately_no_warning(
     assert event.is_late_unregistered(user)
     assert user.has_a_valid_badge([BadgeIds.FirstWarning])
 
+
 def test_unregister_lately_valid_first_warning(
-        client_with_valid_first_warning_badge,
-        user_with_valid_first_warning_badge,
-        event_in_less_than_48h_with_reg
-        ):
+    client_with_valid_first_warning_badge,
+    user_with_valid_first_warning_badge,
+    event_in_less_than_48h_with_reg,
+):
     """
     Tests the late self-unregistration of a user with a valid first warning badge.
     Verifies that the user is correctly unregistered and that badges are assigned as expected.
@@ -272,11 +274,12 @@ def test_unregister_lately_valid_first_warning(
     assert user.has_a_valid_badge([BadgeIds.FirstWarning])
     assert user.has_a_valid_badge([BadgeIds.SecondWarning])
 
+
 def test_unregister_lately_expired_first_warning(
-        client_with_expired_first_warning_badge,
-        user_with_expired_first_warning_badge,
-        event_in_less_than_48h_with_reg
-        ):
+    client_with_expired_first_warning_badge,
+    user_with_expired_first_warning_badge,
+    event_in_less_than_48h_with_reg,
+):
     """
     Tests the late self-unregistration of a user with an expired first warning badge.
     Verifies that the user is correctly unregistered and that badges are assigned as expected.
@@ -302,11 +305,12 @@ def test_unregister_lately_expired_first_warning(
     assert user.has_a_valid_badge([BadgeIds.FirstWarning])
     assert user.matching_badges([BadgeIds.FirstWarning])[0].level == 2
 
+
 def test_unregister_lately_valid_second_warning(
-        client_with_valid_second_warning_badge,
-        user_with_valid_second_warning_badge,
-        event_in_less_than_48h_with_reg
-        ):
+    client_with_valid_second_warning_badge,
+    user_with_valid_second_warning_badge,
+    event_in_less_than_48h_with_reg,
+):
     """
     Tests the late self-unregistration of a user with a valid second warning badge.
     Verifies that the user is correctly unregistered and that badges are assigned as expected.
@@ -325,10 +329,12 @@ def test_unregister_lately_valid_second_warning(
     assert user.has_a_valid_badge([BadgeIds.SecondWarning])
     assert user.has_a_valid_badge([BadgeIds.Banned])
 
+
 def test_unregister_lately_expired_second_warning(
-        client_with_expired_second_warning_badge,
-        user_with_expired_second_warning_badge,
-        event_in_less_than_48h_with_reg):
+    client_with_expired_second_warning_badge,
+    user_with_expired_second_warning_badge,
+    event_in_less_than_48h_with_reg,
+):
     """
     Tests the late self-unregistration of a user with an expired second warning badge.
     Verifies that the user is correctly unregistered and that badges are assigned as expected.
@@ -352,13 +358,14 @@ def test_unregister_lately_expired_second_warning(
     assert not user.has_a_valid_badge([BadgeIds.SecondWarning])
     assert not user.has_a_valid_badge([BadgeIds.Banned])
 
+
 def test_unregister_lately_from_event_with_no_activity_type(
-        client_with_no_warning_badge,
-        user_with_no_warning_badge,
-        event_with_no_activity_type_in_less_than_48h_with_reg
-        ):
+    client_with_no_warning_badge,
+    user_with_no_warning_badge,
+    event_with_no_activity_type_in_less_than_48h_with_reg,
+):
     """
-    Tests the late self-unregistration of a user to an event not requiring an 
+    Tests the late self-unregistration of a user to an event not requiring an
     activity type without any unregistration-related warning badge. Verifies that the user
     is correctly unregistered and that badges are assigned as expected.
     """
@@ -376,11 +383,12 @@ def test_unregister_lately_from_event_with_no_activity_type(
     assert event.is_unregistered(user)
     assert not user.has_a_valid_badge([BadgeIds.FirstWarning])
 
+
 def test_unregister_lately_expired_banned(
-        client_with_expired_banned_badge,
-        user_with_expired_banned_badge,
-        event_in_less_than_48h_with_reg
-        ):
+    client_with_expired_banned_badge,
+    user_with_expired_banned_badge,
+    event_in_less_than_48h_with_reg,
+):
     """
     Tests the late self-unregistration of a user with an expired banned badge.
     Verifies that the user is correctly unregistered and that badges are assigned as expected.
@@ -404,11 +412,12 @@ def test_unregister_lately_expired_banned(
     assert not user.has_a_valid_badge([BadgeIds.SecondWarning])
     assert not user.has_a_valid_badge([BadgeIds.Banned])
 
+
 def test_register_for_valid_banned_user(
-        client_with_valid_banned_badge,
-        user_with_valid_banned_badge,
-        event_in_less_than_48h_with_reg
-        ):
+    client_with_valid_banned_badge,
+    user_with_valid_banned_badge,
+    event_in_less_than_48h_with_reg,
+):
     """
     Tests the self-registration of a user with a valid banned badge.
     Verifies that the user cannot register to the event and that badges are assigned properly.
@@ -429,11 +438,12 @@ def test_register_for_valid_banned_user(
     assert response.status_code == 200
     assert len(event.registrations) == 6
 
+
 def test_register_for_valid_second_warning_user(
-        client_with_valid_second_warning_badge,
-        user_with_valid_second_warning_badge,
-        event_in_less_than_48h
-        ):
+    client_with_valid_second_warning_badge,
+    user_with_valid_second_warning_badge,
+    event_in_less_than_48h,
+):
     """
     Tests the self-registration of a user with a valid second warning badge.
     Verifies that the user is correctly registered to the event.
@@ -450,11 +460,12 @@ def test_register_for_valid_second_warning_user(
     assert response.status_code == 200
     assert len(event.registrations) == 1
 
+
 def test_register_for_valid_first_warning_user(
-        client_with_valid_first_warning_badge,
-        user_with_valid_first_warning_badge,
-        event_in_less_than_48h
-        ):
+    client_with_valid_first_warning_badge,
+    user_with_valid_first_warning_badge,
+    event_in_less_than_48h,
+):
     """
     Tests the self-registration of a user with a valid first warning badge.
     Verifies that the user is correctly registered to the event.
@@ -471,11 +482,12 @@ def test_register_for_valid_first_warning_user(
     assert response.status_code == 200
     assert len(event.registrations) == 1
 
+
 def test_register_for_expired_banned_user(
-        client_with_expired_banned_badge,
-        user_with_expired_banned_badge,
-        event_in_less_than_48h
-        ):
+    client_with_expired_banned_badge,
+    user_with_expired_banned_badge,
+    event_in_less_than_48h,
+):
     """
     Tests the self-registration of a user with an expired banned badge.
     Verifies that the user is correctly registered to the event.
@@ -489,7 +501,6 @@ def test_register_for_expired_banned_user(
 
     assert len(event.registrations) == 0
     assert not event.is_registered(user)
-
 
     response = user_client.post(
         f"/collectives/{event.id}/self_register", follow_redirects=True

--- a/tests/events/test_registrations.py
+++ b/tests/events/test_registrations.py
@@ -1,8 +1,7 @@
 """ Event actions tests related to registrations"""
 
-from datetime import date, timedelta
-from collectives.models import db, RegistrationStatus
-
+from datetime import date, timedelta, datetime
+from collectives.models import db, RegistrationStatus, BadgeIds
 # pylint: disable=unused-argument
 
 
@@ -225,3 +224,279 @@ def test_youth_event_failed_autoregistration(user1, user1_client, youth_event):
     )
     assert response.status_code == 200
     assert youth_event.num_taken_slots() == 0
+
+
+# Late unsubscription-related tests
+def test_unregister_lately_no_warning(
+        client_with_no_warning_badge,
+        user_with_no_warning_badge,
+        event_in_less_than_48h_with_reg
+        ):
+    """
+    Tests the late self-unregistration of a user without any unsubscription-related warning badge.
+    Verifies that the user is correctly unregistered and that badges are assigned as expected.
+    """
+    event = event_in_less_than_48h_with_reg
+    user_client = client_with_no_warning_badge
+    user = user_with_no_warning_badge
+    response = user_client.post(
+        f"/collectives/{event.id}/self_unregister", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert event.num_taken_slots() == 5
+    assert len(event.registrations) == 6
+
+    assert event.is_late_unregistered(user)
+    assert user.has_a_valid_badge([BadgeIds.FirstWarning])
+
+def test_unregister_lately_valid_first_warning(
+        client_with_valid_first_warning_badge,
+        user_with_valid_first_warning_badge,
+        event_in_less_than_48h_with_reg
+        ):
+    """
+    Tests the late self-unregistration of a user with a valid first warning badge.
+    Verifies that the user is correctly unregistered and that badges are assigned as expected.
+    """
+    event = event_in_less_than_48h_with_reg
+    user_client = client_with_valid_first_warning_badge
+    user = user_with_valid_first_warning_badge
+    response = user_client.post(
+        f"/collectives/{event.id}/self_unregister", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert event.num_taken_slots() == 5
+    assert len(event.registrations) == 6
+
+    assert event.is_late_unregistered(user)
+    assert user.has_a_valid_badge([BadgeIds.FirstWarning])
+    assert user.has_a_valid_badge([BadgeIds.SecondWarning])
+
+def test_unregister_lately_expired_first_warning(
+        client_with_expired_first_warning_badge,
+        user_with_expired_first_warning_badge,
+        event_in_less_than_48h_with_reg
+        ):
+    """
+    Tests the late self-unregistration of a user with an expired first warning badge.
+    Verifies that the user is correctly unregistered and that badges are assigned as expected.
+    """
+    event = event_in_less_than_48h_with_reg
+    user_client = client_with_expired_first_warning_badge
+    user = user_with_expired_first_warning_badge
+
+    assert not user.has_a_valid_badge([BadgeIds.FirstWarning])
+    assert user.has_badge([BadgeIds.FirstWarning])
+
+    # Level of None is considered as 1
+    assert user.matching_badges([BadgeIds.FirstWarning])[0].level == None
+
+    response = user_client.post(
+        f"/collectives/{event.id}/self_unregister", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert event.num_taken_slots() == 5
+    assert len(event.registrations) == 6
+
+    assert event.is_late_unregistered(user)
+    assert user.has_a_valid_badge([BadgeIds.FirstWarning])
+    assert user.matching_badges([BadgeIds.FirstWarning])[0].level == 2
+
+def test_unregister_lately_valid_second_warning(
+        client_with_valid_second_warning_badge,
+        user_with_valid_second_warning_badge,
+        event_in_less_than_48h_with_reg
+        ):
+    """
+    Tests the late self-unregistration of a user with a valid second warning badge.
+    Verifies that the user is correctly unregistered and that badges are assigned as expected.
+    """
+    event = event_in_less_than_48h_with_reg
+    user_client = client_with_valid_second_warning_badge
+    user = user_with_valid_second_warning_badge
+    response = user_client.post(
+        f"/collectives/{event.id}/self_unregister", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert event.num_taken_slots() == 5
+    assert len(event.registrations) == 6
+
+    assert event.is_late_unregistered(user)
+    assert user.has_a_valid_badge([BadgeIds.SecondWarning])
+    assert user.has_a_valid_badge([BadgeIds.Banned])
+
+def test_unregister_lately_expired_second_warning(
+        client_with_expired_second_warning_badge,
+        user_with_expired_second_warning_badge,
+        event_in_less_than_48h_with_reg):
+    """
+    Tests the late self-unregistration of a user with an expired second warning badge.
+    Verifies that the user is correctly unregistered and that badges are assigned as expected.
+    """
+    event = event_in_less_than_48h_with_reg
+    user_client = client_with_expired_second_warning_badge
+    user = user_with_expired_second_warning_badge
+
+    assert not user.has_a_valid_badge([BadgeIds.SecondWarning])
+
+    response = user_client.post(
+        f"/collectives/{event.id}/self_unregister", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert event.num_taken_slots() == 5
+    assert len(event.registrations) == 6
+
+    assert event_in_less_than_48h_with_reg.is_late_unregistered(user)
+    # First Warning badge did not exist so it is assigned to the user before a new Second Warning
+    assert user.has_a_valid_badge([BadgeIds.FirstWarning])
+    assert not user.has_a_valid_badge([BadgeIds.SecondWarning])
+    assert not user.has_a_valid_badge([BadgeIds.Banned])
+
+def test_unregister_lately_from_event_with_no_activity_type(
+        client_with_no_warning_badge,
+        user_with_no_warning_badge,
+        event_with_no_activity_type_in_less_than_48h_with_reg
+        ):
+    """
+    Tests the late self-unregistration of a user to an event not requiring an 
+    activity type without any unsubscription-related warning badge. Verifies that the user
+    is correctly unregistered and that badges are assigned as expected.
+    """
+    event = event_with_no_activity_type_in_less_than_48h_with_reg
+    user_client = client_with_no_warning_badge
+    user = user_with_no_warning_badge
+    response = user_client.post(
+        f"/collectives/{event.id}/self_unregister", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert event.num_taken_slots() == 1
+    assert len(event.registrations) == 2
+
+    assert not event.is_late_unregistered(user)
+    assert event.is_unregistered(user)
+    assert not user.has_a_valid_badge([BadgeIds.FirstWarning])
+
+def test_unregister_lately_expired_banned(
+        client_with_expired_banned_badge,
+        user_with_expired_banned_badge,
+        event_in_less_than_48h_with_reg
+        ):
+    """
+    Tests the late self-unregistration of a user with an expired banned badge.
+    Verifies that the user is correctly unregistered and that badges are assigned as expected.
+    """
+    event = event_in_less_than_48h_with_reg
+    user_client = client_with_expired_banned_badge
+    user = user_with_expired_banned_badge
+
+    assert not user.has_a_valid_badge([BadgeIds.Banned])
+
+    response = user_client.post(
+        f"/collectives/{event.id}/self_unregister", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert event.num_taken_slots() == 5
+    assert len(event.registrations) == 6
+
+    assert event_in_less_than_48h_with_reg.is_late_unregistered(user)
+    # First Warning did not exist so it is assigned to the user before a new Second Warning
+    assert user.has_a_valid_badge([BadgeIds.FirstWarning])
+    assert not user.has_a_valid_badge([BadgeIds.SecondWarning])
+    assert not user.has_a_valid_badge([BadgeIds.Banned])
+
+def test_register_for_valid_banned_user(
+        client_with_valid_banned_badge,
+        user_with_valid_banned_badge,
+        event_in_less_than_48h_with_reg
+        ):
+    """
+    Tests the self-registration of a user with a valid banned badge.
+    Verifies that the user cannot register to the event and that badges are assigned properly.
+    """
+    event = event_in_less_than_48h_with_reg
+    user_client = client_with_valid_banned_badge
+    user = user_with_valid_banned_badge
+    response = user_client.get(f"/collectives/{event.id}", follow_redirects=True)
+    assert response.status_code == 200
+    assert user.has_a_valid_badge([BadgeIds.Banned])
+    assert user.has_a_valid_banned_badge()
+    assert len(event.registrations) == 6
+    assert not event.can_self_register(user, datetime.now())
+
+    response = user_client.post(
+        f"/collectives/{event.id}/self_register", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert len(event.registrations) == 6
+
+def test_register_for_valid_second_warning_user(
+        client_with_valid_second_warning_badge,
+        user_with_valid_second_warning_badge,
+        event_in_less_than_48h
+        ):
+    """
+    Tests the self-registration of a user with a valid second warning badge.
+    Verifies that the user is correctly registered to the event.
+    """
+    event = event_in_less_than_48h
+    user_client = client_with_valid_second_warning_badge
+    response = user_client.get(f"/collectives/{event.id}", follow_redirects=True)
+    assert response.status_code == 200
+    assert len(event.registrations) == 0
+
+    response = user_client.post(
+        f"/collectives/{event.id}/self_register", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert len(event.registrations) == 1
+
+def test_register_for_valid_first_warning_user(
+        client_with_valid_first_warning_badge,
+        user_with_valid_first_warning_badge,
+        event_in_less_than_48h
+        ):
+    """
+    Tests the self-registration of a user with a valid first warning badge.
+    Verifies that the user is correctly registered to the event.
+    """
+    event = event_in_less_than_48h
+    user_client = client_with_valid_first_warning_badge
+    response = user_client.get(f"/collectives/{event.id}", follow_redirects=True)
+    assert response.status_code == 200
+    assert len(event.registrations) == 0
+
+    response = user_client.post(
+        f"/collectives/{event.id}/self_register", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert len(event.registrations) == 1
+
+def test_register_for_expired_banned_user(
+        client_with_expired_banned_badge,
+        user_with_expired_banned_badge,
+        event_in_less_than_48h
+        ):
+    """
+    Tests the self-registration of a user with an expired banned badge.
+    Verifies that the user is correctly registered to the event.
+    """
+    event = event_in_less_than_48h
+    user_client = client_with_expired_banned_badge
+    user = user_with_expired_banned_badge
+
+    response = user_client.get(f"/collectives/{event.id}", follow_redirects=True)
+    assert response.status_code == 200
+
+    assert len(event.registrations) == 0
+    assert not event.is_registered(user)
+
+
+    response = user_client.post(
+        f"/collectives/{event.id}/self_register", follow_redirects=True
+    )
+
+    assert response.status_code == 200
+
+    assert event.is_registered(user)
+    assert len(event.registrations) == 1
+    assert not user.has_a_valid_banned_badge()

--- a/tests/events/test_registrations.py
+++ b/tests/events/test_registrations.py
@@ -226,14 +226,14 @@ def test_youth_event_failed_autoregistration(user1, user1_client, youth_event):
     assert youth_event.num_taken_slots() == 0
 
 
-# Late unsubscription-related tests
+# Late unregistration-related tests
 def test_unregister_lately_no_warning(
         client_with_no_warning_badge,
         user_with_no_warning_badge,
         event_in_less_than_48h_with_reg
         ):
     """
-    Tests the late self-unregistration of a user without any unsubscription-related warning badge.
+    Tests the late self-unregistration of a user without any unregistration-related warning badge.
     Verifies that the user is correctly unregistered and that badges are assigned as expected.
     """
     event = event_in_less_than_48h_with_reg
@@ -359,7 +359,7 @@ def test_unregister_lately_from_event_with_no_activity_type(
         ):
     """
     Tests the late self-unregistration of a user to an event not requiring an 
-    activity type without any unsubscription-related warning badge. Verifies that the user
+    activity type without any unregistration-related warning badge. Verifies that the user
     is correctly unregistered and that badges are assigned as expected.
     """
     event = event_with_no_activity_type_in_less_than_48h_with_reg

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -144,3 +144,53 @@ def client_with_expired_benevole_badge(client, user_with_expired_benevole_badge)
     login(client, user_with_expired_benevole_badge)
     yield client
     logout(client)
+
+# User Clients related to late unsubscriptions
+@pytest.fixture
+def client_with_valid_first_warning_badge(client, user_with_valid_first_warning_badge):
+    """Flask client authenticated as user with a valid first warning badge."""
+    login(client, user_with_valid_first_warning_badge)
+    yield client
+    logout(client)
+
+@pytest.fixture
+def client_with_expired_first_warning_badge(client, user_with_expired_first_warning_badge):
+    """Flask client authenticated as user with an expired first warning badge."""
+    login(client, user_with_expired_first_warning_badge)
+    yield client
+    logout(client)
+
+@pytest.fixture
+def client_with_valid_second_warning_badge(client, user_with_valid_second_warning_badge):
+    """Flask client authenticated as user with a valid second warning badge."""
+    login(client, user_with_valid_second_warning_badge)
+    yield client
+    logout(client)
+
+@pytest.fixture
+def client_with_expired_second_warning_badge(client, user_with_expired_second_warning_badge):
+    """Flask client authenticated as user with an expired second warning badge."""
+    login(client, user_with_expired_second_warning_badge)
+    yield client
+    logout(client)
+
+@pytest.fixture
+def client_with_valid_banned_badge(client, user_with_valid_banned_badge):
+    """Flask client authenticated as user with a valid banned badge."""
+    login(client, user_with_valid_banned_badge)
+    yield client
+    logout(client)
+
+@pytest.fixture
+def client_with_expired_banned_badge(client, user_with_expired_banned_badge):
+    """Flask client authenticated as user with an expired banned badge."""
+    login(client, user_with_expired_banned_badge)
+    yield client
+    logout(client)
+
+@pytest.fixture
+def client_with_no_warning_badge(client, user_with_no_warning_badge):
+    """Flask client authenticated as user with no late unsubscription-related warning badge."""
+    login(client, user_with_no_warning_badge)
+    yield client
+    logout(client)

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -145,7 +145,7 @@ def client_with_expired_benevole_badge(client, user_with_expired_benevole_badge)
     yield client
     logout(client)
 
-# User Clients related to late unsubscriptions
+# User Clients related to late unregistrations
 @pytest.fixture
 def client_with_valid_first_warning_badge(client, user_with_valid_first_warning_badge):
     """Flask client authenticated as user with a valid first warning badge."""
@@ -190,7 +190,7 @@ def client_with_expired_banned_badge(client, user_with_expired_banned_badge):
 
 @pytest.fixture
 def client_with_no_warning_badge(client, user_with_no_warning_badge):
-    """Flask client authenticated as user with no late unsubscription-related warning badge."""
+    """Flask client authenticated as user with no late unregistration-related warning badge."""
     login(client, user_with_no_warning_badge)
     yield client
     logout(client)

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -145,6 +145,7 @@ def client_with_expired_benevole_badge(client, user_with_expired_benevole_badge)
     yield client
     logout(client)
 
+
 # User Clients related to late unregistrations
 @pytest.fixture
 def client_with_valid_first_warning_badge(client, user_with_valid_first_warning_badge):
@@ -153,26 +154,36 @@ def client_with_valid_first_warning_badge(client, user_with_valid_first_warning_
     yield client
     logout(client)
 
+
 @pytest.fixture
-def client_with_expired_first_warning_badge(client, user_with_expired_first_warning_badge):
+def client_with_expired_first_warning_badge(
+    client, user_with_expired_first_warning_badge
+):
     """Flask client authenticated as user with an expired first warning badge."""
     login(client, user_with_expired_first_warning_badge)
     yield client
     logout(client)
 
+
 @pytest.fixture
-def client_with_valid_second_warning_badge(client, user_with_valid_second_warning_badge):
+def client_with_valid_second_warning_badge(
+    client, user_with_valid_second_warning_badge
+):
     """Flask client authenticated as user with a valid second warning badge."""
     login(client, user_with_valid_second_warning_badge)
     yield client
     logout(client)
 
+
 @pytest.fixture
-def client_with_expired_second_warning_badge(client, user_with_expired_second_warning_badge):
+def client_with_expired_second_warning_badge(
+    client, user_with_expired_second_warning_badge
+):
     """Flask client authenticated as user with an expired second warning badge."""
     login(client, user_with_expired_second_warning_badge)
     yield client
     logout(client)
+
 
 @pytest.fixture
 def client_with_valid_banned_badge(client, user_with_valid_banned_badge):
@@ -181,12 +192,14 @@ def client_with_valid_banned_badge(client, user_with_valid_banned_badge):
     yield client
     logout(client)
 
+
 @pytest.fixture
 def client_with_expired_banned_badge(client, user_with_expired_banned_badge):
     """Flask client authenticated as user with an expired banned badge."""
     login(client, user_with_expired_banned_badge)
     yield client
     logout(client)
+
 
 @pytest.fixture
 def client_with_no_warning_badge(client, user_with_no_warning_badge):

--- a/tests/fixtures/event.py
+++ b/tests/fixtures/event.py
@@ -261,7 +261,9 @@ def event1_with_answers(event1_with_questions):
     db.session.commit()
     return event1_with_questions
 
+
 inject_fixture("prototype_event_in_less_than_48h", "happens in less than 48 hours")
+
 
 @pytest.fixture
 def event_in_less_than_48h_with_reg(
@@ -271,26 +273,31 @@ def event_in_less_than_48h_with_reg(
     user_with_expired_first_warning_badge,
     user_with_valid_second_warning_badge,
     user_with_expired_second_warning_badge,
-    user_with_expired_banned_badge
-    ): # pylint: disable=too-many-arguments
+    user_with_expired_banned_badge,
+):  # pylint: disable=too-many-arguments
     """
     Returns an event in less than 48 hours
     with registrations for specified users.
     """
 
-    prototype_event_in_less_than_48h.registration_open_time = datetime.now() - timedelta(hours=10)
-    prototype_event_in_less_than_48h.registration_close_time = datetime.now() + timedelta(hours=2)
+    prototype_event_in_less_than_48h.registration_open_time = (
+        datetime.now() - timedelta(hours=10)
+    )
+    prototype_event_in_less_than_48h.registration_close_time = (
+        datetime.now() + timedelta(hours=2)
+    )
     prototype_event_in_less_than_48h.start = datetime.now() + timedelta(hours=3)
     prototype_event_in_less_than_48h.end = datetime.now() + timedelta(hours=4)
     prototype_event_in_less_than_48h.num_online_slots = 9
 
-    for user in [user_with_no_warning_badge,
-                 user_with_valid_first_warning_badge,
-                 user_with_expired_first_warning_badge,
-                 user_with_valid_second_warning_badge,
-                 user_with_expired_second_warning_badge,
-                 user_with_expired_banned_badge
-                 ]:
+    for user in [
+        user_with_no_warning_badge,
+        user_with_valid_first_warning_badge,
+        user_with_expired_first_warning_badge,
+        user_with_valid_second_warning_badge,
+        user_with_expired_second_warning_badge,
+        user_with_expired_banned_badge,
+    ]:
         prototype_event_in_less_than_48h.registrations.append(
             Registration(
                 user_id=user.id,
@@ -305,12 +312,17 @@ def event_in_less_than_48h_with_reg(
 
     return prototype_event_in_less_than_48h
 
+
 @pytest.fixture
 def event_in_less_than_48h(prototype_event_in_less_than_48h):
     """Fixture for an event starting in less than 48 hours."""
 
-    prototype_event_in_less_than_48h.registration_open_time = datetime.now() - timedelta(hours=10)
-    prototype_event_in_less_than_48h.registration_close_time = datetime.now() + timedelta(hours=2)
+    prototype_event_in_less_than_48h.registration_open_time = (
+        datetime.now() - timedelta(hours=10)
+    )
+    prototype_event_in_less_than_48h.registration_close_time = (
+        datetime.now() + timedelta(hours=2)
+    )
     prototype_event_in_less_than_48h.start = datetime.now() + timedelta(hours=3)
     prototype_event_in_less_than_48h.end = datetime.now() + timedelta(hours=4)
 
@@ -321,19 +333,24 @@ def event_in_less_than_48h(prototype_event_in_less_than_48h):
 
     return prototype_event_in_less_than_48h
 
+
 @pytest.fixture
 def event_with_no_activity_type_in_less_than_48h_with_reg(
     prototype_event_in_less_than_48h,
     user_with_no_warning_badge,
     user_with_valid_first_warning_badge,
-    ):
+):
     """
     Returns an event in less than 48 hours
     with registrations for specified users.
     """
 
-    prototype_event_in_less_than_48h.registration_open_time = datetime.now() - timedelta(hours=10)
-    prototype_event_in_less_than_48h.registration_close_time = datetime.now() + timedelta(hours=2)
+    prototype_event_in_less_than_48h.registration_open_time = (
+        datetime.now() - timedelta(hours=10)
+    )
+    prototype_event_in_less_than_48h.registration_close_time = (
+        datetime.now() + timedelta(hours=2)
+    )
     prototype_event_in_less_than_48h.start = datetime.now() + timedelta(hours=3)
     prototype_event_in_less_than_48h.end = datetime.now() + timedelta(hours=4)
     prototype_event_in_less_than_48h.num_online_slots = 9
@@ -346,11 +363,10 @@ def event_with_no_activity_type_in_less_than_48h_with_reg(
     event_type = EventType.query.filter_by(name="Soirée").first()
     prototype_event_in_less_than_48h.event_type = event_type
 
-
-    for user in [user_with_no_warning_badge,
-                 user_with_valid_first_warning_badge,
-
-                 ]:
+    for user in [
+        user_with_no_warning_badge,
+        user_with_valid_first_warning_badge,
+    ]:
         prototype_event_in_less_than_48h.registrations.append(
             Registration(
                 user_id=user.id,

--- a/tests/fixtures/event.py
+++ b/tests/fixtures/event.py
@@ -1,6 +1,6 @@
 """ Module to create fixture events. """
 
-from datetime import date, timedelta
+from datetime import datetime, date, timedelta
 from functools import wraps
 
 import pytest
@@ -260,3 +260,107 @@ def event1_with_answers(event1_with_questions):
     db.session.add(q1)
     db.session.commit()
     return event1_with_questions
+
+inject_fixture("prototype_event_in_less_than_48h", "happens in less than 48 hours")
+
+@pytest.fixture
+def event_in_less_than_48h_with_reg(
+    prototype_event_in_less_than_48h,
+    user_with_no_warning_badge,
+    user_with_valid_first_warning_badge,
+    user_with_expired_first_warning_badge,
+    user_with_valid_second_warning_badge,
+    user_with_expired_second_warning_badge,
+    user_with_expired_banned_badge
+    ): # pylint: disable=too-many-arguments
+    """
+    Returns an event in less than 48 hours
+    with registrations for specified users.
+    """
+
+    prototype_event_in_less_than_48h.registration_open_time = datetime.now() - timedelta(hours=10)
+    prototype_event_in_less_than_48h.registration_close_time = datetime.now() + timedelta(hours=2)
+    prototype_event_in_less_than_48h.start = datetime.now() + timedelta(hours=3)
+    prototype_event_in_less_than_48h.end = datetime.now() + timedelta(hours=4)
+    prototype_event_in_less_than_48h.num_online_slots = 9
+
+    for user in [user_with_no_warning_badge,
+                 user_with_valid_first_warning_badge,
+                 user_with_expired_first_warning_badge,
+                 user_with_valid_second_warning_badge,
+                 user_with_expired_second_warning_badge,
+                 user_with_expired_banned_badge
+                 ]:
+        prototype_event_in_less_than_48h.registrations.append(
+            Registration(
+                user_id=user.id,
+                status=RegistrationStatus.Active,
+                level=RegistrationLevels.Normal,
+                is_self=True,
+            )
+        )
+
+    db.session.add(prototype_event_in_less_than_48h)
+    db.session.commit()
+
+    return prototype_event_in_less_than_48h
+
+@pytest.fixture
+def event_in_less_than_48h(prototype_event_in_less_than_48h):
+    """Fixture for an event starting in less than 48 hours."""
+
+    prototype_event_in_less_than_48h.registration_open_time = datetime.now() - timedelta(hours=10)
+    prototype_event_in_less_than_48h.registration_close_time = datetime.now() + timedelta(hours=2)
+    prototype_event_in_less_than_48h.start = datetime.now() + timedelta(hours=3)
+    prototype_event_in_less_than_48h.end = datetime.now() + timedelta(hours=4)
+
+    prototype_event_in_less_than_48h.num_online_slots = 9
+
+    db.session.add(prototype_event_in_less_than_48h)
+    db.session.commit()
+
+    return prototype_event_in_less_than_48h
+
+@pytest.fixture
+def event_with_no_activity_type_in_less_than_48h_with_reg(
+    prototype_event_in_less_than_48h,
+    user_with_no_warning_badge,
+    user_with_valid_first_warning_badge,
+    ):
+    """
+    Returns an event in less than 48 hours
+    with registrations for specified users.
+    """
+
+    prototype_event_in_less_than_48h.registration_open_time = datetime.now() - timedelta(hours=10)
+    prototype_event_in_less_than_48h.registration_close_time = datetime.now() + timedelta(hours=2)
+    prototype_event_in_less_than_48h.start = datetime.now() + timedelta(hours=3)
+    prototype_event_in_less_than_48h.end = datetime.now() + timedelta(hours=4)
+    prototype_event_in_less_than_48h.num_online_slots = 9
+
+    prototype_event_in_less_than_48h.num_online_slots = 9
+    prototype_event_in_less_than_48h.num_online_slots = 9
+
+    prototype_event_in_less_than_48h.activity_types.clear()
+
+    event_type = EventType.query.filter_by(name="Soirée").first()
+    prototype_event_in_less_than_48h.event_type = event_type
+
+
+    for user in [user_with_no_warning_badge,
+                 user_with_valid_first_warning_badge,
+
+                 ]:
+        prototype_event_in_less_than_48h.registrations.append(
+            Registration(
+                user_id=user.id,
+                status=RegistrationStatus.Active,
+                level=RegistrationLevels.Normal,
+                is_self=True,
+            )
+        )
+
+    db.session.add(prototype_event_in_less_than_48h)
+    db.session.commit()
+
+    return prototype_event_in_less_than_48h

--- a/tests/fixtures/user.py
+++ b/tests/fixtures/user.py
@@ -49,7 +49,7 @@ def generate_user(identifier, names):
         user.is_test = True
         user.license = str(identifier + 990000000000)
         user.license_category = "XX"
-        user.date_of_birth = date(2000, 1, identifier % 30)
+        user.date_of_birth = date(2000, 1, identifier % 28)
         user.password = PASSWORD
         user.phone = f"0601020{identifier:03d}"
         user.emergency_contact_name = f"Emergency {identifier}"
@@ -262,3 +262,94 @@ def add_benevole_badge_to_user(
         activity_type = ActivityType.query.filter_by(name=activity_name).first()
         badge.activity_id = activity_type.id
     db.session.add(badge)
+
+# Users with badges related to late unsubscription
+def add_badge_to_user(
+    user,
+    badge_id,
+    expiration_date=(date.today() + timedelta(days=365)),
+    activity_name="Alpinisme",
+):
+    """Manage to add a badge to a user
+
+    :param User user: the user to add a badge to
+    :expiration_date: the expiration date of the badge (Default is today + 1 year, so a valid one)
+    :param badgeIds badge_id: the type of badge to add
+    :param string activity_name: The activity name for the role. Default Alpinisme
+    """
+    badge = Badge()
+    badge.user_id = user.id
+    badge.badge_id = badge_id
+    badge.expiration_date = expiration_date
+    if activity_name:
+        activity_type = ActivityType.query.filter_by(name=activity_name).first()
+        badge.activity_id = activity_type.id
+    db.session.add(badge)
+
+inject_fixture("prototype_user_with_valid_first_warning_badge", 991, ("Anakin", "Skywalker"))
+
+@pytest.fixture
+def user_with_valid_first_warning_badge(prototype_user_with_valid_first_warning_badge: User):
+    """:returns: A user with a valid first warning Badge."""
+    add_badge_to_user(prototype_user_with_valid_first_warning_badge,
+                      BadgeIds.FirstWarning, date.today() + timedelta(days=60))
+    db.session.add(prototype_user_with_valid_first_warning_badge)
+    db.session.commit()
+    return prototype_user_with_valid_first_warning_badge
+
+inject_fixture("prototype_user_with_expired_first_warning_badge", 990, ("Obi-Wan", "Kenobi"))
+
+@pytest.fixture
+def user_with_expired_first_warning_badge(prototype_user_with_expired_first_warning_badge: User):
+    """:returns: A user with an expired first warning Badge."""
+    add_badge_to_user(prototype_user_with_expired_first_warning_badge,
+                      BadgeIds.FirstWarning, date.today() - timedelta(days=3))
+    db.session.add(prototype_user_with_expired_first_warning_badge)
+    db.session.commit()
+    return prototype_user_with_expired_first_warning_badge
+
+inject_fixture("prototype_user_with_valid_second_warning_badge", 989, ("Han", "Solo"))
+
+@pytest.fixture
+def user_with_valid_second_warning_badge(prototype_user_with_valid_second_warning_badge: User):
+    """:returns: A user with a valid second warning Badge."""
+    add_badge_to_user(prototype_user_with_valid_second_warning_badge,
+                      BadgeIds.SecondWarning, date.today() + timedelta(days=60))
+    db.session.add(prototype_user_with_valid_second_warning_badge)
+    db.session.commit()
+    return prototype_user_with_valid_second_warning_badge
+
+inject_fixture("prototype_user_with_expired_second_warning_badge", 988, ("Leia", "Organa"))
+
+@pytest.fixture
+def user_with_expired_second_warning_badge(prototype_user_with_expired_second_warning_badge: User):
+    """:returns: A user with an expired second warning Badge."""
+    add_badge_to_user(prototype_user_with_expired_second_warning_badge,
+                      BadgeIds.SecondWarning, date.today() - timedelta(days=3))
+    db.session.add(prototype_user_with_expired_second_warning_badge)
+    db.session.commit()
+    return prototype_user_with_expired_second_warning_badge
+
+inject_fixture("prototype_user_with_valid_banned_badge", 987, ("Chewbacca", "The Wookiee"))
+
+@pytest.fixture
+def user_with_valid_banned_badge(prototype_user_with_valid_banned_badge: User):
+    """:returns: A user with a valid banned Badge."""
+    add_badge_to_user(prototype_user_with_valid_banned_badge,
+                      BadgeIds.Banned, date.today() + timedelta(days=60))
+    db.session.add(prototype_user_with_valid_banned_badge)
+    db.session.commit()
+    return prototype_user_with_valid_banned_badge
+
+inject_fixture("prototype_user_with_expired_banned_badge", 986, ("Darth", "Vader"))
+
+@pytest.fixture
+def user_with_expired_banned_badge(prototype_user_with_expired_banned_badge: User):
+    """:returns: A user with an expired banned Badge."""
+    add_badge_to_user(prototype_user_with_expired_banned_badge,
+                      BadgeIds.Banned, date.today() - timedelta(days=3))
+    db.session.add(prototype_user_with_expired_banned_badge)
+    db.session.commit()
+    return prototype_user_with_expired_banned_badge
+
+inject_fixture("user_with_no_warning_badge", 985, ("Jabba", "The Hutt"))

--- a/tests/fixtures/user.py
+++ b/tests/fixtures/user.py
@@ -263,6 +263,7 @@ def add_benevole_badge_to_user(
         badge.activity_id = activity_type.id
     db.session.add(badge)
 
+
 # Users with badges related to late unregistration
 def add_badge_to_user(
     user,
@@ -286,70 +287,117 @@ def add_badge_to_user(
         badge.activity_id = activity_type.id
     db.session.add(badge)
 
-inject_fixture("prototype_user_with_valid_first_warning_badge", 991, ("Anakin", "Skywalker"))
+
+inject_fixture(
+    "prototype_user_with_valid_first_warning_badge", 991, ("Anakin", "Skywalker")
+)
+
 
 @pytest.fixture
-def user_with_valid_first_warning_badge(prototype_user_with_valid_first_warning_badge: User):
+def user_with_valid_first_warning_badge(
+    prototype_user_with_valid_first_warning_badge: User,
+):
     """:returns: A user with a valid first warning Badge."""
-    add_badge_to_user(prototype_user_with_valid_first_warning_badge,
-                      BadgeIds.FirstWarning, date.today() + timedelta(days=60))
+    add_badge_to_user(
+        prototype_user_with_valid_first_warning_badge,
+        BadgeIds.FirstWarning,
+        date.today() + timedelta(days=60),
+    )
     db.session.add(prototype_user_with_valid_first_warning_badge)
     db.session.commit()
     return prototype_user_with_valid_first_warning_badge
 
-inject_fixture("prototype_user_with_expired_first_warning_badge", 990, ("Obi-Wan", "Kenobi"))
+
+inject_fixture(
+    "prototype_user_with_expired_first_warning_badge", 990, ("Obi-Wan", "Kenobi")
+)
+
 
 @pytest.fixture
-def user_with_expired_first_warning_badge(prototype_user_with_expired_first_warning_badge: User):
+def user_with_expired_first_warning_badge(
+    prototype_user_with_expired_first_warning_badge: User,
+):
     """:returns: A user with an expired first warning Badge."""
-    add_badge_to_user(prototype_user_with_expired_first_warning_badge,
-                      BadgeIds.FirstWarning, date.today() - timedelta(days=3))
+    add_badge_to_user(
+        prototype_user_with_expired_first_warning_badge,
+        BadgeIds.FirstWarning,
+        date.today() - timedelta(days=3),
+    )
     db.session.add(prototype_user_with_expired_first_warning_badge)
     db.session.commit()
     return prototype_user_with_expired_first_warning_badge
 
+
 inject_fixture("prototype_user_with_valid_second_warning_badge", 989, ("Han", "Solo"))
 
+
 @pytest.fixture
-def user_with_valid_second_warning_badge(prototype_user_with_valid_second_warning_badge: User):
+def user_with_valid_second_warning_badge(
+    prototype_user_with_valid_second_warning_badge: User,
+):
     """:returns: A user with a valid second warning Badge."""
-    add_badge_to_user(prototype_user_with_valid_second_warning_badge,
-                      BadgeIds.SecondWarning, date.today() + timedelta(days=60))
+    add_badge_to_user(
+        prototype_user_with_valid_second_warning_badge,
+        BadgeIds.SecondWarning,
+        date.today() + timedelta(days=60),
+    )
     db.session.add(prototype_user_with_valid_second_warning_badge)
     db.session.commit()
     return prototype_user_with_valid_second_warning_badge
 
-inject_fixture("prototype_user_with_expired_second_warning_badge", 988, ("Leia", "Organa"))
+
+inject_fixture(
+    "prototype_user_with_expired_second_warning_badge", 988, ("Leia", "Organa")
+)
+
 
 @pytest.fixture
-def user_with_expired_second_warning_badge(prototype_user_with_expired_second_warning_badge: User):
+def user_with_expired_second_warning_badge(
+    prototype_user_with_expired_second_warning_badge: User,
+):
     """:returns: A user with an expired second warning Badge."""
-    add_badge_to_user(prototype_user_with_expired_second_warning_badge,
-                      BadgeIds.SecondWarning, date.today() - timedelta(days=3))
+    add_badge_to_user(
+        prototype_user_with_expired_second_warning_badge,
+        BadgeIds.SecondWarning,
+        date.today() - timedelta(days=3),
+    )
     db.session.add(prototype_user_with_expired_second_warning_badge)
     db.session.commit()
     return prototype_user_with_expired_second_warning_badge
 
-inject_fixture("prototype_user_with_valid_banned_badge", 987, ("Chewbacca", "The Wookiee"))
+
+inject_fixture(
+    "prototype_user_with_valid_banned_badge", 987, ("Chewbacca", "The Wookiee")
+)
+
 
 @pytest.fixture
 def user_with_valid_banned_badge(prototype_user_with_valid_banned_badge: User):
     """:returns: A user with a valid banned Badge."""
-    add_badge_to_user(prototype_user_with_valid_banned_badge,
-                      BadgeIds.Banned, date.today() + timedelta(days=60))
+    add_badge_to_user(
+        prototype_user_with_valid_banned_badge,
+        BadgeIds.Banned,
+        date.today() + timedelta(days=60),
+    )
     db.session.add(prototype_user_with_valid_banned_badge)
     db.session.commit()
     return prototype_user_with_valid_banned_badge
 
+
 inject_fixture("prototype_user_with_expired_banned_badge", 986, ("Darth", "Vader"))
+
 
 @pytest.fixture
 def user_with_expired_banned_badge(prototype_user_with_expired_banned_badge: User):
     """:returns: A user with an expired banned Badge."""
-    add_badge_to_user(prototype_user_with_expired_banned_badge,
-                      BadgeIds.Banned, date.today() - timedelta(days=3))
+    add_badge_to_user(
+        prototype_user_with_expired_banned_badge,
+        BadgeIds.Banned,
+        date.today() - timedelta(days=3),
+    )
     db.session.add(prototype_user_with_expired_banned_badge)
     db.session.commit()
     return prototype_user_with_expired_banned_badge
+
 
 inject_fixture("user_with_no_warning_badge", 985, ("Jabba", "The Hutt"))

--- a/tests/fixtures/user.py
+++ b/tests/fixtures/user.py
@@ -263,7 +263,7 @@ def add_benevole_badge_to_user(
         badge.activity_id = activity_type.id
     db.session.add(badge)
 
-# Users with badges related to late unsubscription
+# Users with badges related to late unregistration
 def add_badge_to_user(
     user,
     badge_id,

--- a/tests/mock/__init__.py
+++ b/tests/mock/__init__.py
@@ -7,4 +7,4 @@ website. To mock it, `monkeypatch`
 a function, a method or a class by another one from this module.
 """
 
-from tests.mock import extranet, payline
+from tests.mock import extranet, payline, session

--- a/tests/mock/session.py
+++ b/tests/mock/session.py
@@ -1,0 +1,32 @@
+""" Mock functions for session. """
+
+import pytest
+
+@pytest.fixture
+def session_monkeypatch(monkeypatch):
+    """
+    Fixture for monkeypatching the session to track calls to add, commit, and rollback.
+    """
+    # Initialize containers to track calls
+    calls = {
+        "add": [],
+        "commit": 0,
+        "rollback": 0,
+    }
+
+    # Define mock functions
+    def add_mock(instance):
+        calls["add"].append(instance)
+
+    def commit_mock():
+        calls["commit"] += 1
+
+    def rollback_mock():
+        calls["rollback"] += 1
+
+    # Use monkeypatch to replace the session methods with mocks
+    monkeypatch.setattr('collectives.models.db.session.add', add_mock)
+    monkeypatch.setattr('collectives.models.db.session.commit', commit_mock)
+    monkeypatch.setattr('collectives.models.db.session.rollback', rollback_mock)
+
+    return calls

--- a/tests/mock/session.py
+++ b/tests/mock/session.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+
 @pytest.fixture
 def session_monkeypatch(monkeypatch):
     """
@@ -25,8 +26,8 @@ def session_monkeypatch(monkeypatch):
         calls["rollback"] += 1
 
     # Use monkeypatch to replace the session methods with mocks
-    monkeypatch.setattr('collectives.models.db.session.add', add_mock)
-    monkeypatch.setattr('collectives.models.db.session.commit', commit_mock)
-    monkeypatch.setattr('collectives.models.db.session.rollback', rollback_mock)
+    monkeypatch.setattr("collectives.models.db.session.add", add_mock)
+    monkeypatch.setattr("collectives.models.db.session.commit", commit_mock)
+    monkeypatch.setattr("collectives.models.db.session.rollback", rollback_mock)
 
     return calls

--- a/tests/unit/test_badges.py
+++ b/tests/unit/test_badges.py
@@ -6,6 +6,7 @@ from collectives.models.badge import Badge, BadgeIds
 from collectives.models import db
 from collectives.models.user import User
 
+
 def test_add_a_valid_badge(user1):
     """Test adding a badge to a user"""
     activity1 = db.session.get(ActivityType, 1)
@@ -60,7 +61,7 @@ def test_add_an_invalid_badge(user2):
 
 def test_assign_badge(user1, session_monkeypatch):
     """
-    Assigns a badge to a user and verifies the session changes. 
+    Assigns a badge to a user and verifies the session changes.
 
     Args:
         user1: The user to assign the badge to.
@@ -69,14 +70,15 @@ def test_assign_badge(user1, session_monkeypatch):
     Returns:
         None
     """
-    badge_id=int(BadgeIds.FirstWarning)
-    expiration_date= date.today() + timedelta(days=1)
+    badge_id = int(BadgeIds.FirstWarning)
+    expiration_date = date.today() + timedelta(days=1)
 
     user1.assign_badge(badge_id, expiration_date=expiration_date, level=1)
 
     assert len(session_monkeypatch["add"]) == 1  # Badge instance should be added
     assert session_monkeypatch["commit"] == 1  # Commit should be called once
     assert session_monkeypatch["rollback"] == 0  # Rollback should not be called
+
 
 def test_update_badge(user1, session_monkeypatch):
     """
@@ -101,6 +103,7 @@ def test_update_badge(user1, session_monkeypatch):
     assert session_monkeypatch["commit"] == 1  # Verify that commit was called once
     assert session_monkeypatch["rollback"] == 0  # Verify that rollback was not called
 
+
 def test_remove_badge(user1, session_monkeypatch):
     """
     Removes a badge from a user and verifies the session changes.
@@ -122,6 +125,7 @@ def test_remove_badge(user1, session_monkeypatch):
     assert session_monkeypatch["commit"] == 1  # Verify that commit was called once
     assert session_monkeypatch["rollback"] == 0  # Verify that rollback was not called
 
+
 def test_update_warning_badges_no_updates(user1, session_monkeypatch, monkeypatch):
     """
     Tests the update_warning_badges method without any
@@ -136,8 +140,8 @@ def test_update_warning_badges_no_updates(user1, session_monkeypatch, monkeypatc
         None
     """
     # Mock the badge condition checks to simulate no updates
-    monkeypatch.setattr(user1, 'has_a_valid_badge', lambda x: False)
-    monkeypatch.setattr(user1, 'has_badge', lambda x: False)
+    monkeypatch.setattr(user1, "has_a_valid_badge", lambda x: False)
+    monkeypatch.setattr(user1, "has_badge", lambda x: False)
 
     user1.update_warning_badges()
 
@@ -146,10 +150,12 @@ def test_update_warning_badges_no_updates(user1, session_monkeypatch, monkeypatc
     assert session_monkeypatch["commit"] == 1  # New commit should occur
     assert session_monkeypatch["rollback"] == 0  # No rollback should occur
 
-    monkeypatch.setattr(user1, 'has_a_valid_badge',
-                    lambda badge_ids: BadgeIds.FirstWarning in badge_ids)
-    monkeypatch.setattr(user1, 'has_badge',
-                    lambda badge_ids: BadgeIds.FirstWarning in badge_ids)
+    monkeypatch.setattr(
+        user1, "has_a_valid_badge", lambda badge_ids: BadgeIds.FirstWarning in badge_ids
+    )
+    monkeypatch.setattr(
+        user1, "has_badge", lambda badge_ids: BadgeIds.FirstWarning in badge_ids
+    )
 
     user1.update_warning_badges()
 
@@ -158,10 +164,14 @@ def test_update_warning_badges_no_updates(user1, session_monkeypatch, monkeypatc
     assert session_monkeypatch["commit"] == 2  # New commit should occur
     assert session_monkeypatch["rollback"] == 0  # No rollback should occur
 
-    monkeypatch.setattr(user1, 'has_a_valid_badge',
-                    lambda badge_ids: BadgeIds.SecondWarning in badge_ids)
-    monkeypatch.setattr(user1, 'has_badge',
-                    lambda badge_ids: BadgeIds.SecondWarning in badge_ids)
+    monkeypatch.setattr(
+        user1,
+        "has_a_valid_badge",
+        lambda badge_ids: BadgeIds.SecondWarning in badge_ids,
+    )
+    monkeypatch.setattr(
+        user1, "has_badge", lambda badge_ids: BadgeIds.SecondWarning in badge_ids
+    )
 
     user1.update_warning_badges()
 
@@ -171,9 +181,12 @@ def test_update_warning_badges_no_updates(user1, session_monkeypatch, monkeypatc
     assert session_monkeypatch["rollback"] == 0  # No rollback should occur
 
     # Mock `matching_badges` to simulate finding more than one badge of a specified type
-    monkeypatch.setattr(user1, 'has_badge', lambda x: True)
-    monkeypatch.setattr(user1, 'matching_badges',
-                        lambda badge_ids=None: [BadgeIds.SecondWarning, BadgeIds.SecondWarning])
+    monkeypatch.setattr(user1, "has_badge", lambda x: True)
+    monkeypatch.setattr(
+        user1,
+        "matching_badges",
+        lambda badge_ids=None: [BadgeIds.SecondWarning, BadgeIds.SecondWarning],
+    )
 
     assert len(user1.matching_badges()) == 2
 

--- a/tests/unit/test_badges.py
+++ b/tests/unit/test_badges.py
@@ -6,7 +6,6 @@ from collectives.models.badge import Badge, BadgeIds
 from collectives.models import db
 from collectives.models.user import User
 
-
 def test_add_a_valid_badge(user1):
     """Test adding a badge to a user"""
     activity1 = db.session.get(ActivityType, 1)
@@ -57,3 +56,128 @@ def test_add_an_invalid_badge(user2):
     retrieved_user = User.query.filter_by(id=user2.id).first()
     assert len(retrieved_user.badges) == 1
     assert not retrieved_user.has_a_valid_benevole_badge()
+
+
+def test_assign_badge(user1, session_monkeypatch):
+    """
+    Assigns a badge to a user and verifies the session changes. 
+
+    Args:
+        user1: The user to assign the badge to.
+        session_monkeypatch: The monkeypatched session for testing.
+
+    Returns:
+        None
+    """
+    badge_id=int(BadgeIds.FirstWarning)
+    expiration_date= date.today() + timedelta(days=1)
+
+    user1.assign_badge(badge_id, expiration_date=expiration_date, level=1)
+
+    assert len(session_monkeypatch["add"]) == 1  # Badge instance should be added
+    assert session_monkeypatch["commit"] == 1  # Commit should be called once
+    assert session_monkeypatch["rollback"] == 0  # Rollback should not be called
+
+def test_update_badge(user1, session_monkeypatch):
+    """
+    Updates a badge for a user and verifies the session changes.
+
+    Args:
+        user1: The user whose badge is being updated.
+        session_monkeypatch: The monkeypatched session for testing.
+
+    Returns:
+        None
+    """
+    badge_id = int(BadgeIds.FirstWarning)
+    new_expiration_date = date.today() + timedelta(days=30)
+    new_level = 2
+
+    # Assuming the user already has a badge that can be updated
+    user1.update_badge(badge_id, expiration_date=new_expiration_date, level=new_level)
+
+    # No 'add' should occur during an update, just commit
+    assert len(session_monkeypatch["add"]) == 0
+    assert session_monkeypatch["commit"] == 1  # Verify that commit was called once
+    assert session_monkeypatch["rollback"] == 0  # Verify that rollback was not called
+
+def test_remove_badge(user1, session_monkeypatch):
+    """
+    Removes a badge from a user and verifies the session changes.
+
+    Args:
+        user1: The user from whom the badge is being removed.
+        session_monkeypatch: The monkeypatched session for testing.
+
+    Returns:
+        None
+    """
+    badge_id = int(BadgeIds.FirstWarning)
+
+    # Assuming the user has a badge to remove
+    user1.remove_badge(badge_id)
+
+    # No 'add' should occur during a removal, just commit
+    assert len(session_monkeypatch["add"]) == 0
+    assert session_monkeypatch["commit"] == 1  # Verify that commit was called once
+    assert session_monkeypatch["rollback"] == 0  # Verify that rollback was not called
+
+def test_update_warning_badges_no_updates(user1, session_monkeypatch, monkeypatch):
+    """
+    Tests the update_warning_badges method without any
+    badge updates and verifies the session changes.
+
+    Args:
+        user1: The user whose warning badges are being updated.
+        session_monkeypatch: The monkeypatched session for testing.
+        monkeypatch: The pytest monkeypatch fixture for mocking.
+
+    Returns:
+        None
+    """
+    # Mock the badge condition checks to simulate no updates
+    monkeypatch.setattr(user1, 'has_a_valid_badge', lambda x: False)
+    monkeypatch.setattr(user1, 'has_badge', lambda x: False)
+
+    user1.update_warning_badges()
+
+    # Verify database operations were performed
+    assert len(session_monkeypatch["add"]) == 1  # New badge should be added
+    assert session_monkeypatch["commit"] == 1  # New commit should occur
+    assert session_monkeypatch["rollback"] == 0  # No rollback should occur
+
+    monkeypatch.setattr(user1, 'has_a_valid_badge',
+                    lambda badge_ids: BadgeIds.FirstWarning in badge_ids)
+    monkeypatch.setattr(user1, 'has_badge',
+                    lambda badge_ids: BadgeIds.FirstWarning in badge_ids)
+
+    user1.update_warning_badges()
+
+    # Verify database operations were performed
+    assert len(session_monkeypatch["add"]) == 2  # New badge should be added
+    assert session_monkeypatch["commit"] == 2  # New commit should occur
+    assert session_monkeypatch["rollback"] == 0  # No rollback should occur
+
+    monkeypatch.setattr(user1, 'has_a_valid_badge',
+                    lambda badge_ids: BadgeIds.SecondWarning in badge_ids)
+    monkeypatch.setattr(user1, 'has_badge',
+                    lambda badge_ids: BadgeIds.SecondWarning in badge_ids)
+
+    user1.update_warning_badges()
+
+    # Verify database operations were performed
+    assert len(session_monkeypatch["add"]) == 3  # New badge should be added
+    assert session_monkeypatch["commit"] == 3  # New commit should occur
+    assert session_monkeypatch["rollback"] == 0  # No rollback should occur
+
+    # Mock `matching_badges` to simulate finding more than one badge of a specified type
+    monkeypatch.setattr(user1, 'has_badge', lambda x: True)
+    monkeypatch.setattr(user1, 'matching_badges',
+                        lambda badge_ids=None: [BadgeIds.SecondWarning, BadgeIds.SecondWarning])
+
+    assert len(user1.matching_badges()) == 2
+
+    # Verify no database operations were performed
+    assert len(session_monkeypatch["add"]) == 3  # No badge should be added
+    assert session_monkeypatch["commit"] == 3  # No commit should occur
+    assert session_monkeypatch["rollback"] == 0  # No rollback should occur


### PR DESCRIPTION
# Feature aiming at reducing the number of late unregistrations to events
https://trello.com/c/kDRVotJB/294-features-pour-r%C3%A9duire-les-d%C3%A9sinscriptions-sauvages

## Functional Schema
![Capture d’écran 2024-02-13 à 12 07 56](https://github.com/Club-Alpin-Annecy/collectives/assets/36108313/70b8ceaa-6755-4d9e-a0b8-b10d79c8e085)
![Capture d’écran 2024-02-13 à 12 08 56](https://github.com/Club-Alpin-Annecy/collectives/assets/36108313/9fdafe85-f0ff-4a82-aa49-09900d18e670)

- An Unregistration is considered late if the event has a required activity (ex : collectives) and if the user unregisters less than 48h prior to the Event starting time

## Key Features

- Leverages the Badges logic to assign 3 types of Badges : `FirstWarning`, `SecondWarning` & `Banned`
- `FirstWarning`, `SecondWarning` expire the next 30th of September
- `Banned` expires 4 weeks after assignment
- When a user has a valid `Banned` badge, he cannot register to an event
- Badge assignment priority is given to the lowest badge (First > Second > Ban)
- 'Se Désinscrire' button now has a proper pop-up screen instead of a flash, personalized if is it whether a late unsubscription or not
- When unregistering lately, an warning or banishment email is sent to the user, according to its warning level
- An Admin can manage badges and can handle banishment if required
- Stats module has a new line chart following Unregistrations, LateUnregistrations & UnjustifiedAbsentees per week over the last 52 weeks

## Things to review or determine in priority

- The whole functional logic
- Transition table possibilities for late unregistrations
- Multi-day events unregistration
- All mails & pop-up contents
- If mailing fails, the logic should still work

## Next ideas / Things to do

- **Leader actions** : transition by a from “LateSelfUnregistered” to “Active” should remove the latest Warning Badge assigned (by default the most valid & restrictive one)
- **Leader actions** : Unjustified Absentees should be handled in the Ban logic
- **Leader actions** : Could excuse a LateSelfUnregistered user remove and latest Warning Badge assigned (by default the most valid & restrictive one)
- **Leader actions** : remove latest Warning Badge assigned (by default the most valid & restrictive one) to "registered" users if an event is cancelled last minute
- Unregistering to Multi-days events should be considered late 7 days before event start (and not 48h)
- A User should see somewhere the remaining banishment time (account suspension) or the number of warnings issues or remaining
- Mailing functional testing
- Rationalize tests using proper factories to generate users, events etc...
- Add a `last_unregistration_time` or `last_self_unregistration_time` to the `Registration` object in order to follow unregistration properly in the stats module
![Capture d’écran 2024-02-13 à 12 11 54](https://github.com/Club-Alpin-Annecy/collectives/assets/36108313/5af1c3b0-5696-4763-ab6f-f2fe30e4c243)

