### PR TITLE
[INTERNAL] Add CORS to allow external site to request event list in js

### DIFF
--- a/collectives/api/event.py
+++ b/collectives/api/event.py
@@ -297,7 +297,11 @@ def events():
     data = EventSchema(many=True).dump(paginated_events.items)
     response = {"data": data, "last_page": paginated_events.pages}
 
-    return json.dumps(response), 200, {"content-type": "application/json"}
+    return (
+        json.dumps(response),
+        200,
+        {"content-type": "application/json", "Access-Control-Allow-Origin": "*"},
+    )
 
 
 class AutocompleteEventSchema(marshmallow.Schema):


### PR DESCRIPTION
Ajout d'un CORS pour permettre au site vitrine de récupérer la liste des collectives en js