### PR TITLE
[Feature]: CSV import extension

### DIFF
--- a/collectives/models/event/event_type.py
+++ b/collectives/models/event/event_type.py
@@ -1,10 +1,12 @@
 """Module to describe the type of event.
 """
 
+from typing import Dict, Any
 from markupsafe import escape
-
+from flask import current_app
 from collectives.models.globals import db
 from collectives.models import Configuration
+from collectives.utils.misc import to_ascii
 
 
 class EventType(db.Model):
@@ -142,3 +144,40 @@ class EventType(db.Model):
 
         confs = {key: Configuration[key] for key in self.TERMS_CONFIGURATIONS}
         return self.terms_title.format(**confs)
+
+    @classmethod
+    def all(cls, include_deprecated=False) -> Dict[int, Dict[str, Any]]:
+        """Returns type dictionnary as defined by EVENT_TYPES in config.
+
+        :param include_deprecated: Whether to include deprecated activity types
+        :type include_deprecated: bool
+
+        :type: dict"""
+
+        types = current_app.config["EVENT_TYPES"]
+        if include_deprecated:
+            return types
+
+        return {
+            id: event_type
+            for id, event_type in types.items()
+            if not event_type.get("deprecated", False)
+        }
+
+    @classmethod
+    def get_type_from_csv_code(cls, csv_code: str) -> int:
+        """
+        :param string short: CSV code of the searched type
+        :returns: Type id
+        """
+
+        # Match without accents, lowercase
+        csv_code = to_ascii(csv_code.strip().lower())
+        for i, event_type in cls.all(include_deprecated=True).items():
+            event_type_csv_code = to_ascii(
+                event_type.get("csv_code", event_type["name"])
+            ).lower()
+            if csv_code == event_type_csv_code:
+                return i
+
+        return None

--- a/collectives/models/event_tag.py
+++ b/collectives/models/event_tag.py
@@ -113,6 +113,8 @@ class EventTag(db.Model):
         :param string short: CSV code of the searched tag
         :returns: Tag id
         """
+        if csv_code == None:
+            return None
 
         # Match without accents, lowercase
         csv_code = to_ascii(csv_code.strip().lower())

--- a/tests/activity/test_csv_import.py
+++ b/tests/activity/test_csv_import.py
@@ -20,11 +20,15 @@ def test_csv_import_form(supervisor_client):
 def test_csv_import(supervisor_client, user1):
     """Test upload of a valid csv file."""
     csv = (
-        ",,,,,,,,,,,,,,,,,\n"
-        "Jan Johnston,990000000001,26/11/2021 7:00,26/11/2021 7:00,Aiguille des Calvaires,"
-        "Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,,\n"
-        "Jan Johnston,990000000001,26/11/2021 7:00,26/11/2021 7:00,Mont Sulens,Aravis,"
-        "d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,,cycle decouverte,,"
+        "nom_encadrant,id_encadrant,debut,fin,titre,secteur,carte_IGN,altitude,"
+        "denivele,cotation,distance,observations,places,places_internet,"
+        "debut_internet,fin_internet,places_liste_attente,parent,tag\n"
+        "Jan Johnston,990000000001,26/11/2021 7:00,26/11/2021 7:00,"
+        "Aiguille des Calvaires,Aravis,d,2322,1200,F,120,d ,8,4,"
+        "19/11/2021 7:00,25/11/2021 12:00,3,,\n"
+        "Jan Johnston,990000000001,26/11/2021 7:00,26/11/2021 7:00,"
+        "Mont Sulens,Aravis,d,2322,1200,F,120,d ,8,4,"
+        "19/11/2021 7:00,25/11/2021 12:00,3,,cycle decouverte"
     )
     file = BytesIO(csv.encode("utf8"))
     activity = supervisor_client.user.get_supervised_activities()[0]
@@ -46,6 +50,7 @@ def test_csv_import(supervisor_client, user1):
     assert event.title == "Aiguille des Calvaires"
     assert event.num_slots == 8
     assert event.num_online_slots == 4
+    assert event.num_waiting_list == 3
     assert event.registration_open_time == datetime(2021, 11, 19, 7, 0, 0)
     assert event.registration_close_time == datetime(2021, 11, 25, 12, 0, 0)
     assert "2322m-1200m-F" in event.rendered_description
@@ -56,12 +61,61 @@ def test_csv_import(supervisor_client, user1):
     assert events[1].tag_refs[0].short == "tag_decouverte"
 
 
+def test_csv_import_multi_tags_leaders(supervisor_client, user1, user2, user3):
+    """Test upload of a valid csv file with event_type multiple leaders and multiple tags."""
+    csv = (
+        "event_type,nom_encadrant,id_encadrant,id_encadrant2,id_encadrant3,"
+        "debut,fin,titre,secteur,carte_IGN,altitude,denivele,cotation,distance,"
+        "observations,places,places_internet,debut_internet,fin_internet,"
+        "places_liste_attente,parent,tag,tag2\n"
+        "acces libre,Jan Johnston,990000000001,990000000002,990000000003,"
+        "26/11/2021 7:00,26/11/2021 7:00,Aiguille des Calvaires,Aravis,d,2322,1200,F,120,"
+        "d ,8,4,19/11/2021 7:00,25/11/2021 12:00,3,,cycle decouverte,rando cool"
+    )
+    file = BytesIO(csv.encode("utf8"))
+    activity = supervisor_client.user.get_supervised_activities()[0]
+
+    data = {
+        "csv_file": (file, "import.csv"),
+        "description": "{altitude}m-{denivele}m-{cotation}",
+        "type": activity.id,
+    }
+
+    response = supervisor_client.post("/activity_supervision/import", data=data)
+    assert response.status_code == 200
+
+    events = Event.query.all()
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type.short == "acces_libre"
+    assert event.title == "Aiguille des Calvaires"
+    assert event.num_slots == 8
+    assert event.num_online_slots == 4
+    assert event.num_waiting_list == 3
+    assert event.registration_open_time == datetime(2021, 11, 19, 7, 0, 0)
+    assert event.registration_close_time == datetime(2021, 11, 25, 12, 0, 0)
+    assert "2322m-1200m-F" in event.rendered_description
+    assert event.leaders[0].license == "990000000001"
+    assert event.leaders[0] == user1
+    assert event.leaders[1].license == "990000000002"
+    assert event.leaders[1] == user2
+    assert event.leaders[2].license == "990000000003"
+    assert event.leaders[2] == user3
+
+    assert len(events[0].tag_refs) == 2
+    assert events[0].tag_refs[0].short == "tag_decouverte"
+    assert events[0].tag_refs[1].short == "tag_rando_cool"
+
+
 def test_csv_import_unknown_leader(supervisor_client, user1):
     """Test upload of an invalid csv with an unkown leader."""
     csv = (
-        ",,,,,,,,,,,,,,,,\n"
+        "nom_encadrant,id_encadrant,debut,fin,titre,secteur,"
+        "carte_IGN,altitude,denivele,cotation,distance,observations,"
+        "places,places_internet,debut_internet,fin_internet,places_liste_attente,parent,tag\n"
         "Evan Walsh,990000000002,26/11/2021 7:00,26/11/2021 7:00,Aiguille des Calvaires,"
-        "Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,,\n"
+        "Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,,,\n"
     )
     file = BytesIO(csv.encode("utf8"))
     activity = supervisor_client.user.get_supervised_activities()[0]

--- a/tests/unit/utils/test_import_csv.py
+++ b/tests/unit/utils/test_import_csv.py
@@ -10,11 +10,17 @@ def test_csv_import(user1):
     """Test importing an event CSV file"""
 
     # pylint: disable=C0301
-    csv = f""",,,,,,,,,,,,,,,\nMr TEST,{user1.license},26/11/2021 7:00,26/11/2021 7:00,Aiguille des Calvaires,Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,,rando cool"""
-
+    csv = (
+        "event_type,nom_encadrant,id_encadrant,debut,fin,titre,secteur,"
+        "carte_IGN,altitude,denivele,cotation,distance,observations,"
+        "places,places_internet,debut_internet,fin_internet,places_liste_attente,parent,tag"
+        f"\naccess libre,Mr TEST,{user1.license},26/11/2021 7:00,26/11/2021 7:00,"
+        "Aiguille des Calvaires,Aravis,d,2322,1200,F,120,d ,8,4,19/11/2021 7:00,25/11/2021 12:00,"
+        "2,,rando cool"
+    )
     output = StringIO(csv)
     events, processed, failed = csv_to_events(
-        output, "{altitude}m-{denivele}m-{cotation}"
+        output, "{altitude}m-{denivele}m-{cotation}", ","
     )
     assert len(events) == 1
     event = events[0]
@@ -23,6 +29,7 @@ def test_csv_import(user1):
     assert event.title == "Aiguille des Calvaires"
     assert event.num_slots == 8
     assert event.num_online_slots == 4
+    assert event.num_waiting_list == 2
     assert event.registration_open_time == datetime.datetime(2021, 11, 19, 7, 0, 0)
     assert event.registration_close_time == datetime.datetime(2021, 11, 25, 12, 0, 0)
     assert "2322m-1200m-F" in event.rendered_description


### PR DESCRIPTION


CSV import extensions:

-     event_type can now be specified as column in csv file. If column is not present, default collectives is used.
-     multiple leaders can now be specified. All columns starting with user_id will be considered for adding leaders. Leaders should be specified as "license_id" or "string(license_id)" or "license_id(string)".
-     multiple tags can now be specified. All columns starting with tag will be considered for adding tags.
-     delimiter is now determined with method csv.Sniffer().sniff

Potential retrocompatibility issues:

-     dictionary keys are now read from first row, thus they need to be specified correctly. Previously they were dictated by app.config["CSV_COLUMNS"] and they needed to have a specific order.
-     All files that did not contain correct key names in first row will not work after this merge request.
