### PR TITLE
[FEATURE] Add organizer roles

### DIFF
--- a/collectives/forms/user.py
+++ b/collectives/forms/user.py
@@ -182,7 +182,7 @@ class RenewBadgeForm(ModelForm, FlaskForm):
         model = Badge
 
     activity_type_id = SelectField("Activité", choices=[], coerce=int)
-    submit = SubmitField("Renouveller")
+    submit = SubmitField("Renouveler")
 
     def __init__(self, *args, **kwargs):
         """Overloaded constructor populating activity list"""
@@ -233,7 +233,7 @@ class AddLeaderForm(ActivityTypeSelectionForm):
     def __init__(self, *args, **kwargs):
         """Overloaded constructor populating activity list"""
         kwargs["activity_list"] = current_user.get_supervised_activities()
-        kwargs["submit_label"] = "Ajouter un encadrant"
+        kwargs["submit_label"] = "Ajouter un rôle"
         super().__init__(*args, **kwargs)
 
 

--- a/collectives/models/__init__.py
+++ b/collectives/models/__init__.py
@@ -6,7 +6,7 @@ submodules classes by importing them. It also create the ``db`` object
 """
 
 from collectives.models.globals import db
-from collectives.models.activity_type import ActivityType, leaders_without_activities
+from collectives.models.activity_type import ActivityType
 from collectives.models.auth import ConfirmationToken, ConfirmationTokenType
 from collectives.models.configuration import ConfigurationItem, ConfigurationTypeEnum
 from collectives.models.configuration import Configuration

--- a/collectives/models/activity_type.py
+++ b/collectives/models/activity_type.py
@@ -135,20 +135,6 @@ class ActivityType(db.Model):
         max_len = getattr(self.__class__, key).prop.columns[0].type.length
         return truncate(value, max_len)
 
-    def can_be_led_by(self, users):
-        """Check if at least anyone in a list can lead an event
-        of this activity
-
-        :param users: list of user to test for leading capabilities
-        :type users: list[:py:class:`collectives.models.user.User`]
-        :return: if someone in the list can lead this activity
-        :rtype: boolean
-        """
-        for user in users:
-            if user.can_lead_activity(self.id):
-                return True
-        return False
-
     @classmethod
     def get_all_types(cls, include_deprecated=False):
         """List all activity_types in database
@@ -182,35 +168,3 @@ class ActivityType(db.Model):
         types = cls.get_all_types()
         items = [f"{type.id}:'{escape(type.name)}'" for type in types]
         return "{" + ",".join(items) + "}"
-
-
-def activities_without_leader(activities, leaders):
-    """Check if leaders has right to lead it.
-
-    Test each activity to see if at least one leader can lead it (see
-    :py:meth:`collectives.models.actitivitytype.ActivityType.can_be_led_by`
-    ).
-    Return the list of activitiers with no valid leader
-
-    :param leaders: List of User which will be tested.
-    :type leaders: list
-    :return: True if leaders can lead all activities.
-    :rtype: boolean
-    """
-    return [a for a in activities if not a.can_be_led_by(leaders)]
-
-
-def leaders_without_activities(activities, leaders):
-    """Check if leaders has right to lead it.
-
-    Test each leader to see if they can lead each activity
-    :py:meth:`collectives.models.actitivitytype.ActivityType.can_be_led_by`
-    ).
-    Return the list of leaders not able to lead all activities
-
-    :param leaders: List of User which will be tested.
-    :type leaders: list
-    :return: True if leaders can lead all activities.
-    :rtype: boolean
-    """
-    return [l for l in leaders if not l.can_lead_activities(activities)]

--- a/collectives/models/badge.py
+++ b/collectives/models/badge.py
@@ -20,7 +20,7 @@ class BadgeIds(ChoiceEnum):
         :rtype: string
         """
         return {
-            cls.Benevole: "Bénévole",
+            cls.Benevole: "Bénévole régulier",
         }
 
     def relates_to_activity(self) -> bool:

--- a/collectives/models/event/__init__.py
+++ b/collectives/models/event/__init__.py
@@ -10,6 +10,7 @@ from collectives.models.event.event_type import EventType
 from collectives.models.event.misc import EventMiscMixin, photos
 from collectives.models.event.payment import EventPaymentMixin
 from collectives.models.event.role import EventRoleMixin
+from collectives.models.event.role import event_activities_without_leaders
 from collectives.models.event.registration import EventRegistrationMixin
 
 

--- a/collectives/models/event/event_type.py
+++ b/collectives/models/event/event_type.py
@@ -88,7 +88,7 @@ class EventType(db.Model):
     """
 
     def has_valid_license(self, user):
-        """Check whether an user has a valic license for this type of event
+        """Check whether an user has a valid license for this type of event
 
         :param user: The user whose license should be checked
         :param user: :py:class:`collectives.models.user.User`

--- a/collectives/models/event/misc.py
+++ b/collectives/models/event/misc.py
@@ -113,6 +113,9 @@ class EventMiscMixin:
         # date is meant to be used only by an online user while registering.
         # The leader or administrater is always able to register someone even if
         # registration date are closed.
+        if self.event_type.requires_activity and not self.activity_types:
+            return False
+
         if self.num_online_slots == 0:
             return (
                 self.starts_before_ends()

--- a/collectives/models/user/badge.py
+++ b/collectives/models/user/badge.py
@@ -2,7 +2,6 @@
 
 from typing import List, Optional, Set
 
-from datetime import date
 from collectives.models.badge import Badge, BadgeIds
 
 from collectives.models.activity_type import ActivityType
@@ -27,8 +26,7 @@ class UserBadgeMixin:
         if not valid_only:
             return list(badges)
 
-        today = date.today()
-        return [badge for badge in badges if badge.expiration_date > today]
+        return [badge for badge in badges if not badge.is_expired()]
 
     def has_badge(self, badge_ids: List[BadgeIds]) -> bool:
         """Check if user has at least one of the badges types.

--- a/collectives/routes/activity_supervison.py
+++ b/collectives/routes/activity_supervison.py
@@ -118,7 +118,7 @@ def leader_list():
         "activity_supervision/leaders_list.html",
         add_leader_form=add_leader_form,
         export_form=export_form,
-        title="Encadrants",
+        title="Encadrants et Organisateurs",
     )
 
 

--- a/collectives/static/js/activity_supervision/badges_list.js
+++ b/collectives/static/js/activity_supervision/badges_list.js
@@ -39,7 +39,7 @@ function loadBadgesTable(ajaxUrl, ajaxParams, csrfToken) {
                 { title: "Expiration", field: "expiration_date", headerFilter: "input", widthGrow: 3},
                 { title: "Niveau", field: "level", headerFilter: "input", widthGrow: 2, visible: false},
                 { field: "delete_uri", formatter: actionFormatter(csrfToken), formatterParams: { 'icon': 'md-trash', 'method': 'POST', 'alt': 'Delete' }, cellClick: onclickTriggerInsideForm, headerSort: false },
-                { field: "renew_uri", formatter: actionFormatter(csrfToken), formatterParams: { 'icon': 'refresh', 'method': 'POST', 'alt': 'Renouveller' }, cellClick: onclickTriggerInsideForm, headerSort: false },            
+                { field: "renew_uri", formatter: actionFormatter(csrfToken), formatterParams: { 'icon': 'refresh', 'method': 'POST', 'alt': 'Renouveler' }, cellClick: onclickTriggerInsideForm, headerSort: false },            
             ],
 
             langs: {

--- a/collectives/templates/activity_supervision/activity_supervision.html
+++ b/collectives/templates/activity_supervision/activity_supervision.html
@@ -13,11 +13,11 @@
     </a>
     <a class="button button-primary" href="{{ url_for('activity_supervision.leader_list')}}">
       <img class="icon invert-color" src="{{ url_for('static', filename='img/icon/ionicon/people.svg') }}"/>
-      Encadrants
+      Encadrants et Organisateurs
     </a>
     <a class="button button-primary" href="{{ url_for('activity_supervision.volunteers_list')}}">
         <img class="icon invert-color" src="{{ url_for('static', filename='img/icon/ionicon/thumbs-up.svg') }}"/>
-      Bénévoles
+        Bénévoles réguliers
       </a>
     <a class="button button-primary" href="{{ url_for('activity_supervision.csv_import')}}">
       <img class="icon invert-color" src="{{ url_for('static', filename='img/icon/ionicon/download.svg') }}"/>

--- a/collectives/templates/activity_supervision/badges_list.html
+++ b/collectives/templates/activity_supervision/badges_list.html
@@ -40,6 +40,13 @@
 
   <h4 class="heading-4">Ajout/renouvellement d'un {{title}}</h4>
 
+  {%if type == models.BadgeIds.Benevole %}
+  <p>Le badge <em>{{title}}</em> permet d'identifier les personnes ayant suffisamment contribué à l'activité pour bénéficier des avantages bénévole.
+  Attention, détenir un rôle (encadrant ou autre) pour l'activité ne donnera bientôt plus automatiquement accès à ces avantages ; il faut
+  renouveler le badge chaque année.
+  </p>
+  {% endif %}
+  
   {{ generator.form_generator(add_badge_form, url_for(routes['add'])) }}
 
   <h4 class="heading-4">Export de la liste</h4>

--- a/collectives/templates/activity_supervision/leaders_list.html
+++ b/collectives/templates/activity_supervision/leaders_list.html
@@ -32,10 +32,17 @@
 
 {% block page_content %}
 <div class="page-content" id="administration">
-  <h2 class="heading-2">Encadrants</h2>
+  <h2 class="heading-2">Encadrants et Organisateurs</h2>
   <div id="leaders-table"></div>
 
-  <h4 class="heading-4">Ajout d'un encadrant</h4>
+  <strong>Signification des rôles:</strong>
+  <ul>
+    <li><em>{{models.RoleIds.EventLeader.display_name()}}</em> : Peut créer et encadrer tout type d'événement lié à l'activité, dont des collectives.</li>
+    <li><em>{{models.RoleIds.Trainee.display_name()}}</em> : Peut être noté comme co-encadrant d'un événement auquel il est inscrit. Peut créer certains types d'événements ne nécéssitant pas d'autorisation d'encadrement (soirées ...), mais ne peut pas créer de collectives.
+    <li><em>{{models.RoleIds.ActivityStaff.display_name()}}</em> : Peut créer certains types d'événements ne nécéssitant pas d'autorisation d'encadrement (soirées ...), mais ne peut pas créer de collectives.
+  </ul>
+
+  <h4 class="heading-4">Ajout d'un encadrant ou organisateur</h4>
 
   {{ generator.form_generator(add_leader_form, url_for('activity_supervision.add_leader')) }}
 

--- a/collectives/templates/event/editevent.html
+++ b/collectives/templates/event/editevent.html
@@ -41,7 +41,7 @@
         const searchInput = document.getElementById('new-leader');
         setupAutoComplete(
           searchInput,
-          '{{url_for("api.autocomplete_available_leaders", eid=form.current_leader_ids(), aid=form.leader_activity_ids()) | safe}}',
+          '{{url_for("api.autocomplete_available_leaders", eid=form.current_leader_ids(), aid=form.leader_activity_ids(), etype=form.current_event_type().id) | safe}}',
           function(item) {
             return item.full_name;
           },

--- a/collectives/templates/event/event.html
+++ b/collectives/templates/event/event.html
@@ -241,7 +241,7 @@
             <form action="{{url_for('profile.force_user_sync')}}" method="post" id="refresh_extranet">
               <p>
                 Votre licence va expirer avant la fin de l'événement; votre demande d'inscription a été prise en compte, mais ne sera confirmée qu'une fois le renouvellement effectif.
-                Si vous venez de renouveller votre licence, merci de resynchroniser vos informations FFCAM via le bouton ci-dessous. <br />
+                Si vous venez de renouveler votre licence, merci de resynchroniser vos informations FFCAM via le bouton ci-dessous. <br />
                 <button type="submit" class="button button-secondary">
                   <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-ribbon.svg') }}"/> Resynchroniser mes informations FFCAM
                 </button>

--- a/collectives/templates/event/partials/admin.html
+++ b/collectives/templates/event/partials/admin.html
@@ -145,7 +145,7 @@
                             {{ registration.user.full_name() }}
                             {% if registration.is_pending_renewal() %}
                                 {% set ns.license_to_renew = True %}
-                                <img src="{{url_for('static', filename='img/icon/ionicon/md-time.svg')}}" alt="&#128337;" class="icon" title="Licence à renouveller"/>
+                                <img src="{{url_for('static', filename='img/icon/ionicon/md-time.svg')}}" alt="&#128337;" class="icon" title="Licence à renouveler"/>
                             {% endif %}{{license_to_renew}}
                         </a>
                     </td>
@@ -178,8 +178,8 @@
             </tbody>
         </table>
             {% if ns.license_to_renew %}
-            <img src="{{url_for('static', filename='img/icon/ionicon/md-time.svg')}}" alt="&#128337;" class="icon" title="Licence à renouveller"/>
-            = Licence à renouveller <br/>
+            <img src="{{url_for('static', filename='img/icon/ionicon/md-time.svg')}}" alt="&#128337;" class="icon" title="Licence à renouveler"/>
+            = Licence à renouveler <br/>
             {% endif %}
 
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/><br/>

--- a/collectives/templates/profile.html
+++ b/collectives/templates/profile.html
@@ -135,12 +135,12 @@
     <h4 class="heading-4">Autres informations</h4>
         <table id="site_info" class="center_table">
             <tr>
-                <td class="head"><img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/thumbs-up.svg') }}" alt=""/> Bénévolat :</td>
+                <td class="head"><img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/thumbs-up.svg') }}" alt=""/> Bénévolat régulier :</td>
                 <td>
                     {% if user.has_a_valid_benevole_badge() %}
-                        {% for badge in user.badges if badge.badge_id == models.BadgeIds.Benevole and not badge.is_expired() %}
+                        {% for activity in user.activities_with_valid_badge([models.BadgeIds.Benevole])  %}
                             {% if loop.index != 1 %} & {% endif %}
-                            {{badge.activity_name}} 
+                            {{activity.name}} 
                         {% endfor %}
                     {% else %}
                         Non
@@ -148,9 +148,9 @@
                 </td>
             </tr>
             <tr>
-                <td class="head"><img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-ribbon.svg') }}" alt=""/> Role sur le site :</td>
+                <td class="head"><img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-ribbon.svg') }}" alt=""/> Rôle(s) sur le site :</td>
                 <td>
-                    {% if user.has_a_valid_benevole_badge() %}
+                    {% if user.roles %}
                         {% for role in user.roles %}
                             {% if loop.index != 1 %} & {% endif %}
                             {{role.name}}


### PR DESCRIPTION
Ajoute le rôle "Organisateur (activité)", qui permet de créer des événements d'un type ne demandant pas d'autorisation d'encadrement (e.g. soirées). Ce rôle peur être attribué par le responsable d'activité.

`+` quelques renames pour plus de clarté:
 - Rôle "Bénévole" -> "Organisateur (club)". Peut créer des événements sans lien avec une activité, attribué par l'admin/président
 - Badge "Bénévole" -> Bénévole régulier

`+` explication des rôles dans l'interface activité
`+` nettoyage