### PR TITLE
[FIX] Fix truncated long answer in answer table

### DIFF
--- a/collectives/static/js/question/show_answers.js
+++ b/collectives/static/js/question/show_answers.js
@@ -39,7 +39,7 @@ function createShowAnswersTable(url, csrfToken)
           columns:[
             {title:"Auteur", field:"author_name", widthGrow:1, headerFilter:true},
             {title:"État", field:"registration_status", widthGrow:1, headerFilter:true, editor: "select", headerFilterParams:{values: makeStatusFilter()}},
-            {title:"Réponse", field:"value", widthGrow:4, headerFilter:true},
+            {title:"Réponse", field:"value", widthGrow:4, headerFilter:true, formatter:"textarea"},
             {field: "delete_uri", formatter: actionFormatter(csrfToken), formatterParams: { 'icon': 'trash', 'method': 'POST', 'alt': 'Delete' }, cellClick: submitDeleteForm, headerSort: false },
         ],
 


### PR DESCRIPTION
Les réponses longues au questionnaire sont tronquées par tabulator. Je fais sauter ça :)
![Screenshot 2024-05-11 at 18-05-49 Collectives](https://github.com/Club-Alpin-Annecy/collectives/assets/45011516/f856fdfd-a04f-4c06-b79d-d23317ff2ad2)
