### PR TITLE
[FEATURE] Strike expired users in autocomplete

### DIFF
--- a/collectives/api/autocomplete_user.py
+++ b/collectives/api/autocomplete_user.py
@@ -31,6 +31,7 @@ class AutocompleteUserSchema(marshmallow.Schema):
         fields = (
             "id",
             "full_name",
+            "license_expiry_date",
         )
 
 

--- a/collectives/static/js/utils/autocomplete.js
+++ b/collectives/static/js/utils/autocomplete.js
@@ -54,7 +54,15 @@ function setupAutoComplete(
     const renderItem = function (item) {
         var val = itemValue(item);
         var innerHTML = settings.itemInnerHTML(item, val);
-        return `<div class="${settings.itemClass}" data-val='${escapeHTML(val)}' data-id="${item.id}">${innerHTML}</div>`
+        if (new Date(item.license_expiry_date) < new Date() ){
+            var style = "text-decoration-line: line-through; color: grey; font-style: italic;"
+            var misc = `(expiré)`
+        }
+        else {
+            var style = ""; 
+            var misc = "";
+        }
+        return `<div class="${settings.itemClass}" data-val='${escapeHTML(val)}' data-id="${item.id}" style="${style}">${innerHTML} ${misc}</div>`
     };
 
     return new window.autoComplete({


### PR DESCRIPTION
Permet d'éviter la sélection de compte expiré, notamment si un utilisateur a un compte en double (par exemple, lors d'un renouvellement avec un numéro de licence et d'email différent)