### PR TITLE
Fix question creation, add ways to copy questions

### DIFF
--- a/collectives/forms/question.py
+++ b/collectives/forms/question.py
@@ -7,6 +7,7 @@ from flask_wtf import FlaskForm
 from wtforms_alchemy import ModelForm
 from wtforms import Field, SubmitField, HiddenField, FieldList, FormField, BooleanField
 from wtforms import TextAreaField, SelectField, SelectMultipleField, IntegerField
+from wtforms import StringField
 
 from wtforms.validators import Optional, ValidationError, InputRequired
 
@@ -215,3 +216,12 @@ class QuestionAnswersForm(FlaskForm):
             return "\n".join([choices[idx] for idx in data])
 
         return str(data)
+
+
+class CopyQuestionsForm(ModelForm, FlaskForm):
+    """Form to copy questions from an event to another."""
+
+    submit = SubmitField("Copier")
+    purge = BooleanField("Purge")
+    copied_event_id = HiddenField()
+    copied_event_search = StringField("Evénement à copier")

--- a/collectives/models/event/payment.py
+++ b/collectives/models/event/payment.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 
+import collectives
 from collectives.models.registration import RegistrationStatus
 from collectives.models.user import User
 from collectives.utils.time import current_time
@@ -58,21 +59,35 @@ class EventPaymentMixin:
             p for p in self.user_payments(user) if p.is_unsettled() or p.is_approved()
         )
 
-    def copy_payment_items(self, source_event, time_shift=timedelta(0)):
+    def copy_payment_items(
+        self,
+        source_event: "collectives.models.Event",
+        time_shift: timedelta = timedelta(0),
+    ):
         """Copy Payment item of another event into this event.
 
         Do not copy payments.
 
         :param source_event: Event that will be copied
-        :type source_event: :py:class:`collectives.models.event.Event`
         :param time_shift: Optionnal shift of copied item prices dates
-        :type time_shift: :py:class:`datetime.timedelta`"""
+        """
         for payment in source_event.payment_items:
             self.payment_items.append(
                 payment.copy(
                     time_shift, old_event_id=source_event.id, new_event_id=self.id
                 )
             )
+
+    def copy_questions(self, source_event: "collectives.models.Event"):
+        """Copy questionnaire of another event into this event.
+
+        Do not copy answers.
+
+        :param source_event: Event that will be copied
+        """
+
+        for question in source_event.questions:
+            self.questions.append(question.copy(new_event_id=self.id))
 
     def exist_available_prices_to_user(self, user: User) -> bool:
         """:returns: whether there exist currently available prices for an user

--- a/collectives/models/question.py
+++ b/collectives/models/question.py
@@ -145,6 +145,23 @@ class Question(db.Model):
         """:returns: the list of possible choices for the question"""
         return self.make_choices_array(self.choices)
 
+    def copy(self, new_event_id: int = None):
+        """Copy current question.
+
+        :returns: Copied questions"""
+
+        question = Question()
+        question.event_id = new_event_id
+        question.title = self.title
+        question.description = self.description
+        question.choices = self.choices
+        question.question_type = self.question_type
+        question.order = self.order
+        question.required = self.required
+        question.enabled = self.enabled
+
+        return question
+
 
 class QuestionAnswer(db.Model):
     """Database model describing a set of questions"""

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -591,6 +591,7 @@ def manage_event(event_id=None):
         if duplicated_event != None:
             event.photo = duplicated_event.photo
             event.copy_payment_items(duplicated_event)
+            event.copy_questions(duplicated_event)
 
             db.session.add(event)
             db.session.commit()

--- a/collectives/templates/payment/edit_prices.html
+++ b/collectives/templates/payment/edit_prices.html
@@ -41,7 +41,6 @@
 
     eventSearchInput.addEventListener('change', function(event) {
         if(!event.target.value) {
-          var field = document.getElementById('copy-item-event-id');
           parentEventInput.value = "";
         }
     });
@@ -168,8 +167,8 @@
       Aucun tarif n'a été défini pour le moment.
     {%endif%}
 
-    <h5 class="heading-5"> Nouveau tarif </h5>
-    <form method="POST" id="new_price">
+    <form method="POST" id="new_price" class="form form-vertical">
+    <h4 class="heading-4"> Nouveau tarif </h4>
 
     <div class="form-errors">
         {% for field_name, errors in new_price_form.errors.items() %}
@@ -181,23 +180,32 @@
         {% endfor %}
     </div>
 
-    <div class="field">{{ new_price_form.existing_item.label }}<span class="help">Ajouter le tarif à un objet existant ou créer un nouvel objet</span></div>
+    <div class="controls">{{ new_price_form.existing_item.label(class="label-top") }}<span class="label-help">Ajouter le tarif à un objet existant ou créer un nouvel objet</span>
     {{ new_price_form.existing_item(onchange="updateNewItemTitleVisibility();")}}
+    </div>
     <div id = "new-item-title">
-      <div class="field">{{ new_price_form.item_title.label }}<span class="help">Par exemple «Nuitée en refuge»</span></div>
-      {{ new_price_form.item_title}}
+      <div class="controls">{{ new_price_form.item_title.label }}<span class="label-help">Par exemple «Nuitée en refuge»</span>
+      {{ new_price_form.item_title(class="input-100")}}
+      </div>
     </div>
-    <div class="field">{{ new_price_form.title.label }}<span class="help">Par exemple «Adultes»</span></div>
-    {{ new_price_form.title}}
 
-    <div class="field">{{ new_price_form.amount.label }}<span class="help">{{ new_price_form.amount.description }}</span></div>
-    {{ new_price_form.amount(type="number", min="0.00", max=config['PAYMENTS_MAX_PRICE'], step="0.01", lang="fr-FR")}}
+    <div class="controls">
+    {{ new_price_form.title.label(class="label-top")}}<span class="label-help">Par exemple «Adultes»</span>
+    {{ new_price_form.title(class="input-100")}}
+    </div>
+
+    <div class="controls">
+    {{ new_price_form.amount.label(class="label-top") }}<span class="label-help">{{ new_price_form.amount.description }}</span>
+    {{ new_price_form.amount(class="input-25", type="number", min="0.00", max=config['PAYMENTS_MAX_PRICE'], step="0.01", lang="fr-FR")}}
     {#{ new_price_form.amount()}#}
-
-    <div class="field">
-    {{ new_price_form.enabled }} 
     </div>
+
+    <div class="controls">
+    <div class="label-top">
+    {{ new_price_form.enabled }} 
     {{new_price_form.enabled.label}}
+    </div>
+    </div>
  
     <fieldset>
     <legend>Conditions pour bénéficier du tarif</legend>
@@ -224,19 +232,24 @@
     </form>
 
     <h4 class="heading-4">Copie de tarif</h4>
-    <form method="POST" class="form" action="{{url_for('payment.copy_prices', event_id=event.id)}}">
-        <p>Copier les tarifs d'un autre collective.</p>
+    <form method="POST" class="form form-vertical" action="{{url_for('payment.copy_prices', event_id=event.id)}}">
+        <p>Copier les tarifs d'une autre collective.</p>
 
-        <div class="field">{{copy_item_form.copied_event_search.label}}  <span class="help">Titre ou ID</span></div>
-        {{ copy_item_form.copied_event_search(id='copy-item-event-search') }}
+        <div class="controls">
+        {{copy_item_form.copied_event_search.label(class="label-top")}}  
+        <span class="label-help">Titre ou ID</span>
+        {{ copy_item_form.copied_event_search(id='copy-item-event-search', class='input-100') }}
         {{ copy_item_form.copied_event_id(id='copy-item-event-id') }}
+        </div>
 
-        <div class="field"> 
+        <div class="controls">
+        <div class="label-top">
+        {{ copy_item_form.purge }}
           {{ copy_item_form.purge.label }} 
-          <span class="help">Les tarifs actuels seront supprimés. 
+        </div>
+        <span class="label-help">Les tarifs actuels seront supprimés. 
           Si un tarif a déjà fait l'objet d'un paiement, il sera seulement désactivé.</span>
         </div>
-        {{ copy_item_form.purge }}
         
 
         {{ copy_item_form.hidden_tag() }}

--- a/collectives/templates/question/edit_questions.html
+++ b/collectives/templates/question/edit_questions.html
@@ -169,7 +169,7 @@
     </form>
 
     <h4 class="heading-4">Copie de questionnaire</h4>
-    <form method="POST" class="form form-vertical" action="{{url_for('question.copy_questions', event_id=event.id)}}">
+    <form method="POST" id="copy_questions" class="form form-vertical" action="{{url_for('question.copy_questions', event_id=event.id)}}">
         <p>Copier les questions d'une autre collective.</p>
 
         <div class="controls">

--- a/collectives/templates/question/edit_questions.html
+++ b/collectives/templates/question/edit_questions.html
@@ -1,6 +1,47 @@
 
 {% extends 'base.html' %}
 
+{% block additionalhead %}
+  <!-- Auto complete scripts -->
+  <script src="https://unpkg.com/js-autocomplete@1.0.4/auto-complete.min.js"></script>
+  <link href="https://unpkg.com/js-autocomplete@1.0.4/auto-complete.css" rel="stylesheet">
+  <script src="{{ url_for('static', filename='js/tools.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/utils/autocomplete.js') }}"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
+
+  <script> 
+  function loadEventAutoComplete(eventSearchInputID, parentEventInputID){
+    const eventSearchInput = document.getElementById(eventSearchInputID);
+    const parentEventInput = document.getElementById(parentEventInputID);
+
+    setupAutoComplete(
+      eventSearchInput,
+      '{{url_for("api.autocomplete_event", eid=[event.id]) | safe}}',
+      function(item) {
+        return formatParentEvent(item.id, item.title, item.start) ;
+      },
+      function(id, val) {
+        parentEventInput.value = id;
+      }
+      );
+
+    eventSearchInput.addEventListener('change', function(event) {
+        if(!event.target.value) {
+          parentEventInput.value = "";
+        }
+    });
+
+    eventSearchInput.value = parentEventInput.value;
+
+  };
+  
+
+  window.onload = function() {
+    loadEventAutoComplete('copy-question-event-search', 'copy-question-event-id');
+  };
+  </script>
+{% endblock %}
+
 {% block content %}
 <div class="page-content" id="administration">
   <h1 class="heading-1">{{event.title}}</h1>
@@ -125,6 +166,33 @@
  
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <br />{{ new_question_form.add(class="button button-primary") }}
+    </form>
+
+    <h4 class="heading-4">Copie de questionnaire</h4>
+    <form method="POST" class="form form-vertical" action="{{url_for('question.copy_questions', event_id=event.id)}}">
+        <p>Copier les questions d'une autre collective.</p>
+
+        <div class="controls">
+        {{copy_questions_form.copied_event_search.label(class="label-top")}}  
+        <div class="label-help">Titre ou ID</div>
+        {{ copy_questions_form.copied_event_search(id='copy-question-event-search', class="input-100") }}
+        {{ copy_questions_form.copied_event_id(id='copy-question-event-id') }}
+        </div>
+
+        <div class="field"> 
+        </div>
+        
+        <div class="controls">
+        <div class="label-top">
+        {{ copy_questions_form.purge }}
+        {{ copy_questions_form.purge.label }} 
+        </div>
+        <span class="label-help">Les questions actuelles seront supprimées. 
+        Si une réponse à la question existe déjà, elle sera seulement désactivée.</span>
+        </div>
+
+        {{ copy_questions_form.hidden_tag() }}
+        {{ copy_questions_form.submit(class="button button-primary") }}
     </form>
 
 </div>

--- a/collectives/templates/question/edit_questions.html
+++ b/collectives/templates/question/edit_questions.html
@@ -17,7 +17,6 @@
     <thead>
       <th> Intitulé / Description</th>
       <th> Type / Réponses possibles</th>
-      <th> Options</th>
     </thead>
     {% for question_form in form.questions %}
       {{question_form.question_id}}
@@ -41,21 +40,25 @@
           <td>
             {{ question_form.question_type() }}
           </td>
-          <td class="actions" rowspan="2"> 
-          {{question_form.enabled}} {{question_form.enabled.label}} <br/>
-          {{question_form.required}} {{question_form.required.label}} <br/>
-          {{question_form.order.label}}: {{question_form.order}} <br/>
-          {% if not question_form.question.answers %}
-            {{question_form.delete}}&nbsp;{{question_form.delete.label}}
-          {% endif %} 
-          </td>
         </tr>
-        <tr class="{{ loop.cycle('odd', 'even') }} fields bottom " >
+        <tr class="{{ loop.cycle('odd', 'even') }} fields " >
           <td>
             {{question_form.description}}
           </td>
           <td>
             {{question_form.choices}}
+          </td>
+        </tr>
+        <tr class="{{ loop.cycle('odd', 'even') }} fields bottom " >
+          <td> 
+          {{question_form.enabled}}&nbsp;{{question_form.enabled.label}}
+          {{question_form.required}}&nbsp;{{question_form.required.label}}
+          {% if not question_form.question.answers %}
+            {{question_form.delete}}&nbsp;{{question_form.delete.label}}
+          {% endif %} 
+          </td>
+          <td>
+          {{question_form.order.label}}: {{question_form.order}} <br/>
           </td>
         </tr>
     {% endfor %}
@@ -68,8 +71,8 @@
       Aucune question n'a été créée pour le moment.
   {%endif%}
 
-    <h5 class="heading-5"> Nouvelle question</h5>
-    <form method="POST" id="new_question">
+    <form method="POST" id="new_question" class="form form-vertical">
+    <h4 class="heading-4"> Nouvelle question</h4>
 
     <div class="form-errors">
         {% for field_name, errors in new_question_form.errors.items() %}
@@ -81,30 +84,44 @@
         {% endfor %}
     </div>
 
-    <div class="field">{{ new_question_form.title.label }}</div>
-    {{ new_question_form.title}}
-    
-    <div class="field">{{ new_question_form.description.label }}<span class="help">{{ new_question_form.description.description }}</span></div>
-    {{ new_question_form.description}}
+    <div class="controls">
+    {{ new_question_form.title.label(class="label-top") }}
+    {{ new_question_form.title(class="input-100")}}
+    </div>
 
-    <div class="field">{{ new_question_form.question_type.label }}<span class="help">{{ new_question_form.question_type.description }}</span></div>
+    <div class="controls">
+    {{ new_question_form.description.label(class="label-top") }}<div class="label-help">{{ new_question_form.description.description }}</div>
+    {{ new_question_form.description(rows=12)}}
+    </div>
+
+    <div class="controls">
+    {{ new_question_form.question_type.label(class="label-top") }}<div class="label-help">{{ new_question_form.question_type.description }}</div>
     {{ new_question_form.question_type}}
+    </div>
     
-    <div class="field">{{ new_question_form.choices.label }}<span class="help">{{ new_question_form.choices.description }}</span></div>
-    {{ new_question_form.choices}}
+    <div class="controls">
+    {{ new_question_form.choices.label(class="label-top") }}<div class="label-help">{{ new_question_form.choices.description }}</div>
+    {{ new_question_form.choices(rows=8)}}
+    </div>
     
-    <div class="field">{{ new_question_form.order.label }}<span class="help">{{ new_question_form.order.description }}</span></div>
-    {{ new_question_form.order}}
+    <div class="controls">
+    {{ new_question_form.order.label(class="label-top") }}<div class="label-help">{{ new_question_form.order.description }}</div>
+    {{ new_question_form.order(class="input-25")}}
+    </div>
     
-    <div class="field">
+    <div class="controls">
+    <div class="label-top">
     {{ new_question_form.required }} 
-    </div>
     {{new_question_form.required.label}}
-
-    <div class="field">
-    {{ new_question_form.enabled }} 
     </div>
+    </div>
+
+    <div class="controls">
+    <div class="label-top">
+    {{ new_question_form.enabled }} 
     {{new_question_form.enabled.label}}
+    </div>
+    </div>
  
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <br />{{ new_question_form.add(class="button button-primary") }}


### PR DESCRIPTION


- Corrige l'affichage des forms de création de tarifs/questions (incompatibilités avec le nouveau CSS du site)
 - Copie les questions lorsqu'on duplique un event
 - Ajout d'un form de copie des questions d'un autre event (comme pour les tarifs) 