### PR TITLE
Fix overbooking

### DIFF
--- a/collectives/models/registration.py
+++ b/collectives/models/registration.py
@@ -1,6 +1,7 @@
 """Module for registration related classes
 """
 
+from operator import attrgetter
 from collectives.models.globals import db
 from collectives.models.utils import ChoiceEnum
 
@@ -262,3 +263,72 @@ class Registration(db.Model):
         return [self.status] + self.status.valid_transitions(
             self.event.requires_payment()
         )
+
+    def holding_index(self) -> int:
+        """Returns the chronlogical place this registration has in all holding place registrations.
+        None if not active. Starts at 1."""
+        if not self.is_holding_slot():
+            return None
+        regs = self.event.registrations
+        return (
+            sorted(
+                [r for r in regs if r.is_holding_slot()], key=attrgetter("id")
+            ).index(self)
+            + 1
+        )
+
+    def online_index(self) -> int:
+        """Returns the chronlogical place this registration has in all online and holding slot
+        registrations. None if not holding slot and online. Starts at 1."""
+        if not self.is_self or not self.is_holding_slot():
+            return None
+        regs = self.event.registrations
+        return (
+            sorted(
+                [r for r in regs if r.is_self and self.is_holding_slot()],
+                key=attrgetter("id"),
+            ).index(self)
+            + 1
+        )
+
+    def waiting_index(self) -> int:
+        """Returns the chronlogical place this registration has in waiting registrations.
+        None if not waiting. Starts at 1."""
+        status = RegistrationStatus.Waiting
+        if self.status != status:
+            return None
+        regs = self.event.registrations
+        return (
+            sorted([r for r in regs if r.status == status], key=attrgetter("id")).index(
+                self
+            )
+            + 1
+        )
+
+    def is_overbooked(self) -> bool:
+        """Check if the registration is not overbooking.
+
+        An overbooked registration is:
+
+        - | an online registration with more previous Waiting registration
+          | than online slots
+        - | or an holding place registration with more previous holding place registration
+          | than total slots
+        - | a Waiting registration with more previous Waiting registration
+          | than Waiting slots
+
+        """
+
+        if self.waiting_index() is not None:
+            if self.waiting_index() > self.event.num_waiting_slots:
+                return True
+
+        if self.holding_index() is not None:
+            if self.holding_index() > self.event.num_slots:
+                return True
+
+        if self.online_index() is not None:
+            if self.online_index() > self.event.num_online_slots:
+                return True
+
+        return False

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -718,6 +718,11 @@ def self_register(event_id):
         event.registrations.append(registration)
         db.session.commit()
 
+        db.session.expire(event)
+        if registration.is_overbooked():
+            db.session.delete(registration)
+            flash("L'évènement est complet.", "error")
+
         return redirect(url_for("event.view_event", event_id=event_id))
 
     # Paid event
@@ -736,6 +741,12 @@ def self_register(event_id):
         registration.status = RegistrationStatus.PaymentPending
         event.registrations.append(registration)
         db.session.commit()
+
+        db.session.expire(event)
+        if registration.is_overbooked():
+            db.session.delete(registration)
+            flash("L'évènement est complet.", "error")
+            return redirect(url_for("event.view_event", event_id=event_id))
 
         payment = Payment(registration=registration, item_price=item_price)
         payment.terms_version = Configuration.PAYMENTS_TERMS_FILE

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ markupsafe
 flask
 Werkzeug
 flask-assets
-git+https://github.com/maxcountryman/flask-login.git@2204b4eee7b215977ba5a1bf85e2061f7fa65e20#egg=flask-login
+git+https://github.com/maxcountryman/flask-login.git@26d12eaa99a18fc91e662ef0c8466245b8865c1c#egg=flask-login
 sqlalchemy
 flask_sqlalchemy
 sqlalchemy-utils

--- a/tests/unit/test_registrations.py
+++ b/tests/unit/test_registrations.py
@@ -1,0 +1,50 @@
+""" Unit tests for registrations"""
+
+from collectives.models import db, RegistrationStatus, Registration, RegistrationLevels
+
+
+def test_overflow(user1, user2, user3, user4, event):
+    """Test an auto registration to a full event without waiting list"""
+
+    event.num_waiting_slots = 1
+    event.num_slots = 1
+    db.session.add(event)
+    db.session.commit()
+
+    reg1 = Registration(
+        user_id=user1.id,
+        status=RegistrationStatus.Active,
+        level=RegistrationLevels.Normal,
+        is_self=True,
+    )
+    reg2 = Registration(
+        user_id=user2.id,
+        status=RegistrationStatus.Active,
+        level=RegistrationLevels.Normal,
+        is_self=True,
+    )
+    reg3 = Registration(
+        user_id=user3.id,
+        status=RegistrationStatus.Waiting,
+        level=RegistrationLevels.Normal,
+        is_self=True,
+    )
+    reg4 = Registration(
+        user_id=user4.id,
+        status=RegistrationStatus.Waiting,
+        level=RegistrationLevels.Normal,
+        is_self=True,
+    )
+
+    event.registrations.append(reg1)
+    event.registrations.append(reg2)
+    event.registrations.append(reg3)
+    event.registrations.append(reg4)
+
+    db.session.add(event)
+    db.session.commit()
+
+    assert reg1.is_overbooked() == False
+    assert reg2.is_overbooked() == True
+    assert reg3.is_overbooked() == False
+    assert reg4.is_overbooked() == True


### PR DESCRIPTION
On a toujours ce problème d'inscriptions concurentes: j'aimerais les fix en les détectant et en les enlevant. C'est donc la DB qui fait foi pour savoir quelle inscription il faut conserver.

Je ne dis pas qu'on ne pourrait pas trouver une solution plus élégante, mais elle me parait suffisamment simple.