### PR TITLE
[FIX] Only logout non-renewed user if they are the one doing the sync

### DIFF
--- a/collectives/routes/profile.py
+++ b/collectives/routes/profile.py
@@ -163,7 +163,7 @@ def force_user_sync(user_id):
             return redirect(url_for("profile.show_user", user_id=user.id))
 
     try:
-        if not sync_user(user, force=True):
+        if not sync_user(user, force=True) and user.id == current_user.id:
             flash(
                 f'Votre numéro de licence "{user.license}" n\'est pas ou plus valide '
                 "dans la base fédérale. Si un nouveau numéro de licence vous a été attribué, "

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -144,3 +144,11 @@ def client_with_expired_benevole_badge(client, user_with_expired_benevole_badge)
     login(client, user_with_expired_benevole_badge)
     yield client
     logout(client)
+
+
+@pytest.fixture
+def extranet_user_client(client, extranet_user):
+    """Flask client authenticated as extranet_user user."""
+    login(client, extranet_user)
+    yield client
+    logout(client)

--- a/tests/fixtures/user.py
+++ b/tests/fixtures/user.py
@@ -8,6 +8,8 @@ import pytest
 from collectives.models import User, Gender, db, Role, RoleIds, ActivityType
 from collectives.models import Badge, BadgeIds, UserType
 
+from tests.mock.extranet import VALID_LICENSE
+
 # pylint: disable=unused-argument,redefined-outer-name
 
 PASSWORD = "fooBar2+!"
@@ -208,6 +210,21 @@ def user_with_expired_benevole_badge(prototype_user_with_expired_benevole_badge:
     db.session.add(prototype_user_with_expired_benevole_badge)
     db.session.commit()
     return prototype_user_with_expired_benevole_badge
+
+
+inject_fixture("prototype_extranet_user", 991, ("Extranet", "User"))
+
+
+@pytest.fixture
+def extranet_user(prototype_extranet_user):
+    """:returns: A user with type extranet."""
+    prototype_extranet_user.type = UserType.Extranet
+    prototype_extranet_user.license = VALID_LICENSE
+    prototype_extranet_user.license_expiry_date = date.today() + timedelta(days=365)
+
+    db.session.add(prototype_extranet_user)
+    db.session.commit()
+    return prototype_extranet_user
 
 
 def promote_to_leader(user, activity="Alpinisme"):

--- a/tests/mock/extranet.py
+++ b/tests/mock/extranet.py
@@ -124,7 +124,7 @@ class FakeSoapClient:
             }
         if license == EXPIRED_LICENSE:
             return {
-                "existe": 1,
+                "existe": 0,
                 "id": license,
                 "nom": "EXPIRED",
                 "prenom": "BOB",


### PR DESCRIPTION
+ Add unit tests for resyncing expired user