### PR TITLE
feat(event-filters): increase multi select viewport & hide clear on empty filter

### DIFF
--- a/collectives/static/js/event/eventlist-filters.component.js
+++ b/collectives/static/js/event/eventlist-filters.component.js
@@ -45,6 +45,7 @@ export default {
       optionLabel="name" 
       optionValue="id"
       filter 
+      scrollHeight="90vh"
       placeholder="Toutes activités"
     >
       <template #option="slotProps">
@@ -56,8 +57,8 @@ export default {
       <template #chip="slotProps">
           <Chip :label="findInConfig(config.activityList, slotProps.value).name" :image="'/static/caf/icon/' + slotProps.value + '.svg'" removable @remove="filters.activities = filters.activities.filter(id => id !== slotProps.value)"/>
       </template>
-      <template #footer>
-        <div class="p-3 flex justify-between">
+      <template #footer="slotProps">
+        <div class="flex justify-between" v-if="slotProps.value.length > 0">
             <div></div>
             <Button label="Effacer" severity="danger" text size="small" icon="pi pi-times" @click="filters.activities = []" />
         </div>
@@ -80,6 +81,7 @@ export default {
         :options="config.eventTypes" 
         optionLabel="name" 
         optionValue="id"
+        scrollHeight="90vh"
         placeholder="Tout types d'événement"
         display="chip" 
         filter 
@@ -93,8 +95,8 @@ export default {
         <template #chip="slotProps">
             <Chip :label="findInConfig(config.eventTypes, slotProps.value).name" :image="'/static/caf/icon/' + slotProps.value + '.svg'" removable @remove="filters.eventTypes = filters.eventTypes.filter(id => id !== slotProps.value)" />
         </template>
-        <template #footer>
-          <div class="p-3 flex justify-between">
+        <template #footer="slotProps">
+          <div class="flex justify-between" v-if="slotProps.value?.length > 0">
               <div></div>
               <Button label="Effacer" severity="danger" text size="small" icon="pi pi-times" @click="filters.eventTypes = []" />
           </div>
@@ -107,6 +109,7 @@ export default {
         :options="config.eventTags" 
         optionLabel="name" 
         optionValue="id"
+        scrollHeight="90vh"
         placeholder="Tous labels"
         display="chip" 
         filter 
@@ -120,8 +123,8 @@ export default {
         <template #chip="slotProps">
             <Chip :label="findInConfig(config.eventTags, slotProps.value).name" :image="'/static/caf/icon/' + slotProps.value + '.svg'" removable @remove="filters.eventTags = filters.eventTags.filter(id => id !== slotProps.value)" />
         </template>
-        <template #footer>
-          <div class="p-3 flex justify-between">
+        <template #footer="slotProps">
+          <div class="flex justify-between" v-if="slotProps.value?.length > 0">
               <div></div>
               <Button label="Effacer" severity="danger" text size="small" icon="pi pi-times" @click="filters.eventTags = []" />
           </div>

--- a/collectives/static/js/event/eventlist-skeleton.component.js
+++ b/collectives/static/js/event/eventlist-skeleton.component.js
@@ -4,11 +4,10 @@ export default {
   },
   template: `
   <div
-    class="tabulator-row tabulator-selectable tabulator-row-odd"
-    style="padding-left: 0px"
+    class="tabulator-row tabulator-selectable"
   >
     <div
-      class="row tabulator-cell collectives-list-item"
+      class="row collectives-list--item"
     >
       <div class="section collectives-list--item--photo">
         <Skeleton width="277.5px" height="185px"></Skeleton>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/06616611-22a3-498a-ad64-c8975e6a8670)

## Features
- Hide "clear filter" button, when filter is inactive
- Max height for the multiselect dropdown is 90vh (90% viewport height)
- Fix layout for the event card empty state (when loading)