### PR TITLE
Nicer error messages when usi a license  number from another club

### DIFF
--- a/collectives/forms/validators.py
+++ b/collectives/forms/validators.py
@@ -7,6 +7,7 @@ See `WTForms documentation
 import re
 
 from wtforms.validators import ValidationError
+from wtforms import Field, Form
 from wtforms_alchemy import Unique
 
 from collectives.models import Configuration
@@ -19,20 +20,17 @@ class LicenseValidator:
     length = 12
     """ Length of the license number.
 
-    Type: string """
+    Type: int """
 
-    def __call__(self, form, field):
-        """Validates the license field data.
+    def __call__(self, form: Form, field: Field) -> bool:
+        """Validates the license field data (check length and prefix)
 
         :param form: Form of the field.
-        :type form: :py:class:`wtforms.form.Form`
         :param field: The license field.
-        :type: :py:class:`wtforms.Field`
         :return: True if data is OK.
-        :rtype: boolean
         """
         if not re.match(self.pattern(), field.data):
-            error_message = "Le numéro de licence doit contenir 12 chiffres"
+            error_message = f"Le numéro de licence doit contenir {self.help_string()}"
             raise ValidationError(error_message)
 
     def help_string(self):

--- a/collectives/routes/administration.py
+++ b/collectives/routes/administration.py
@@ -512,6 +512,12 @@ def generate_token():
                 "error",
             )
             return redirect(url_for(".administration"))
+    except extranet.LicenseBelongsToOtherClubError:
+        flash(
+            "Ce numéro de licence appartient à un autre club",
+            "error",
+        )
+        return redirect(url_for(".administration"))
     except extranet.ExtranetError:
         flash(
             "Impossible de se connecter à l'extranet, veuillez réessayer ultérieurement",

--- a/collectives/routes/auth/utils.py
+++ b/collectives/routes/auth/utils.py
@@ -49,10 +49,15 @@ def sync_user(user: User, force: bool):
     if not user.enabled or user.type != UserType.Extranet:
         return
 
-    # Check whether the license has been renewed
-    license_info = extranet.api.check_license(user.license)
     time = current_time()
-    if not license_info.is_valid_at_time(time):
+    try:
+        # Check whether the license has been renewed
+        license_info = extranet.api.check_license(user.license)
+        valid = license_info.is_valid_at_time(time)
+    except extranet.LicenseBelongsToOtherClubError:
+        valid = False
+
+    if not valid:
         if user.license_expiry_date > time.date():
             current_app.logger.warning(
                 f"User #{user.id} synchronization : license is not active on extranet "

--- a/tests/mock/extranet.py
+++ b/tests/mock/extranet.py
@@ -3,6 +3,9 @@
 from datetime import date, timedelta
 import pytest
 
+from zeep.exceptions import Error as ZeepError
+from collectives.utils.extranet import _OTHER_CLUB_LICENSE_MESSAGE
+
 # pylint: disable=unused-argument,redefined-builtin
 
 VALID_LICENSE = "740020780001"
@@ -15,6 +18,9 @@ VALID_LICENSE_WITH_NO_EMAIL = "740020780003"
 """ A license number linked to a valid extranet account
     but without an email adress
 """
+
+OTHER_CLUB_LICENSE = "741020780002"
+""" A license number linked to an account from another club"""
 
 VALID_USER_EMAIL = "test@example.com"
 """ Email stored in extranet for VALID_LICENSE """
@@ -53,6 +59,8 @@ class FakeSoapClient:
         :returns: All data related to this license
         :rtype: dict"""
         license = kwargs["id"]
+        if license == OTHER_CLUB_LICENSE:
+            raise ZeepError(_OTHER_CLUB_LICENSE_MESSAGE)
 
         data = {
             "id": license,
@@ -120,6 +128,8 @@ class FakeSoapClient:
         :returns: some data related to this license
         :rtype: dict"""
         license = kwargs["id"]
+        if license == OTHER_CLUB_LICENSE:
+            raise ZeepError(_OTHER_CLUB_LICENSE_MESSAGE)
         if license in (VALID_LICENSE, VALID_LICENSE_WITH_NO_EMAIL):
             # Registered 15 days ago
             reg_date = date.today() - timedelta(days=15)
@@ -131,6 +141,7 @@ class FakeSoapClient:
                 "inscription": reg_date.isoformat(),
                 "assurance_personne": 1,
             }
+
         if license == EXPIRED_LICENSE:
             return {
                 "existe": 0,

--- a/tests/test_extranet.py
+++ b/tests/test_extranet.py
@@ -96,6 +96,17 @@ def test_wrong_create_account(client, extranet_monkeypatch):
     assert response.status_code == 200
     assert "flash-error" in response.text
 
+    # license from other club
+    data = {
+        "mail": "test@example.com",
+        "license": mock.extranet.OTHER_CLUB_LICENSE,
+        "date_of_birth": "2022-10-04",
+    }
+    response = client.post("/auth/signup", data=data)
+    assert response.status_code == 200
+    assert "flash-error" in response.text
+    assert "licence doit contenir" in response.text
+
 
 def test_resync_own_account(client, extranet_user, extranet_monkeypatch):
     """Test extranet resync."""
@@ -187,6 +198,17 @@ def test_hotline_resync_account(hotline_client, extranet_user, extranet_monkeypa
     assert response.status_code == 200
     assert "error message" in response.text
     assert "pas ou plus valide" in response.text
+
+    # Same if license from other club
+    extranet_user.license = mock.extranet.OTHER_CLUB_LICENSE
+    db.session.add(extranet_user)
+    db.session.commit()
+
+    response = hotline_client.post(
+        f"/profile/user/{extranet_user.id}/force_sync", follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert "error message" in response.text
 
 
 def test_user_resync_account(user1_client, user2, extranet_monkeypatch):


### PR DESCRIPTION
Maintenant que l'api extranet est réparée elle renvoie des auth error lorsqu'on utilise un  numéro d'un autre club. Détecte et affiche un message plus adapté