### PR TITLE
[FEATURE] Add event type filter to statistics page

### DIFF
--- a/collectives/forms/stats.py
+++ b/collectives/forms/stats.py
@@ -2,10 +2,10 @@
 
 from datetime import date
 
-from wtforms import SelectField, SubmitField
+from wtforms import SelectField, SelectMultipleField, SubmitField
 
 from collectives.forms.activity_type import ActivityTypeSelectionForm
-from collectives.models import Event
+from collectives.models import Event, EventType
 from collectives.utils.time import get_ffcam_year
 
 
@@ -17,6 +17,9 @@ class StatisticsParametersForm(ActivityTypeSelectionForm):
 
     year = SelectField()
     """ Year to display """
+
+    event_type_ids = SelectMultipleField("Types d'événement", coerce=int, validators=[])
+    """ Event types to restrict statistics to. Empty means all event types. """
 
     submit = SubmitField(label="Sélectionner")
     """ Submit button for regular HTML display """
@@ -32,6 +35,10 @@ class StatisticsParametersForm(ActivityTypeSelectionForm):
         self.activity_id.choices = [
             (self.ALL_ACTIVITIES, "Toutes activités"),
             *self.activity_id.choices,
+        ]
+
+        self.event_type_ids.choices = [
+            (event_type.id, event_type.name) for event_type in EventType.get_all_types()
         ]
 
         first_event = Event.query.order_by(Event.start).first()

--- a/collectives/routes/root.py
+++ b/collectives/routes/root.py
@@ -57,12 +57,13 @@ def statistics():
     """Displays site event statistics."""
     form = StatisticsParametersForm(formdata=request.args)
     if form.validate():
-        if form.activity_id.data == form.ALL_ACTIVITIES:
-            engine = StatisticsEngine(year=form.year.data)
-        else:
-            engine = StatisticsEngine(
-                activity_id=form.activity_id.data, year=form.year.data
-            )
+        kwargs = {
+            "year": form.year.data,
+            "event_type_ids": form.event_type_ids.data,
+        }
+        if form.activity_id.data != form.ALL_ACTIVITIES:
+            kwargs["activity_id"] = form.activity_id.data
+        engine = StatisticsEngine(**kwargs)
     else:
         engine = StatisticsEngine(year=StatisticsParametersForm().year.data)
 

--- a/collectives/templates/stats/stats.html
+++ b/collectives/templates/stats/stats.html
@@ -29,6 +29,35 @@
 
   <script src="{{ url_for('api.models_to_js') }}"></script>
 
+  {# Multi-select #}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+  <script>
+    window.addEventListener('load', function () {
+      const select = document.getElementById('event_type_ids');
+      const choices = new Choices(select, {
+        removeItemButton: true,
+        noChoicesText: "Pas d'autres choix disponibles",
+        noResultsText: "Aucun choix trouvé",
+        itemSelectText: "Ajouter",
+        placeholder: true,
+        placeholderValue: "Tous les types d'événement",
+      });
+
+      // Choices.js keeps the placeholder on a multi-select even once items are
+      // selected; clear it while there is at least one selection.
+      function updatePlaceholder() {
+        const input = choices.input.element;
+        input.placeholder = choices.getValue(true).length
+          ? ""
+          : "Tous les types d'événement";
+      }
+      select.addEventListener('addItem', updatePlaceholder);
+      select.addEventListener('removeItem', updatePlaceholder);
+      updatePlaceholder();
+    });
+  </script>
+
 {% endblock %}
 
 {% block content %}
@@ -39,6 +68,8 @@
 
     <form action="{{url_for('root.statistics')}}" id="statistics-form" method="GET" class="filters">
           {{ form.activity_id }}
+
+          {{ form.event_type_ids(class="choices", title="Types d'événement (aucun = tous)") }}
 
           {{ form.year }}
 

--- a/collectives/utils/stats.py
+++ b/collectives/utils/stats.py
@@ -44,8 +44,16 @@ class StatisticsEngine:
 
     activity_id = None
     """ All statistics of the engine will be limited to the activity with this id
-    
+
     :type: int
+    """
+
+    event_type_ids = None
+    """ All statistics of the engine will be limited to events of these event types.
+
+    An empty or ``None`` value means no restriction on event type.
+
+    :type: list[int]
     """
 
     start = None
@@ -296,6 +304,8 @@ class StatisticsEngine:
             condition = condition & (
                 Event.activity_types.any(ActivityType.id == self.activity_id)
             )
+        if self.event_type_ids:
+            condition = condition & (Event.event_type_id.in_(self.event_type_ids))
 
         if query_type == Event:
             query = query.filter(condition)
@@ -629,7 +639,11 @@ class StatisticsEngine:
 
     def __str__(self) -> str:
         """Returns string representation of Engine"""
-        return f"{self.activity_id}/{self.start}->{self.end}/{self.time_segment()}"
+        event_types = ",".join(str(i) for i in sorted(self.event_type_ids or []))
+        return (
+            f"{self.activity_id}/{event_types}/"
+            f"{self.start}->{self.end}/{self.time_segment()}"
+        )
 
     def __hash__(self) -> int:
         """Return unique hash based on StatisticsEngine parameters"""
@@ -639,6 +653,7 @@ class StatisticsEngine:
         """Check if two StatisticsEngine are equivalent."""
         return (
             self.activity_id == other.activity_id
+            and sorted(self.event_type_ids or []) == sorted(other.event_type_ids or [])
             and self.start == other.start
             and self.end == other.end
             and self.time_segment() == other.time_segment()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 import openpyxl
 
-from collectives.models import ActivityType
+from collectives.models import ActivityType, EventType
 from collectives.utils.stats import StatisticsEngine
 from collectives.utils.time import current_time
 
@@ -120,3 +120,23 @@ def test_statistics_engine_only_alpi(stats_env, leader2_user):
     assert engine.mean_registrations_per_day() is None
 
     assert openpyxl.load_workbook(filename=engine.export_excel())
+
+
+def test_statistics_engine_only_party(stats_env):
+    """Tests statistics engine restricted to a set of event types."""
+    party = EventType.query.filter_by(name="Soirée").first()
+    collective = EventType.query.filter_by(name="Collective").first()
+
+    # Single event type: only the "Soirée" event (event3) is kept.
+    engine = StatisticsEngine(event_type_ids=[party.id])
+    assert engine.nb_events() == 1
+    assert engine.nb_events_by_event_type() == {"Soirée": 1}
+
+    # Set of event types behaves as the union of each type.
+    engine = StatisticsEngine(event_type_ids=[party.id, collective.id])
+    assert engine.nb_events() == 6
+    assert set(engine.nb_events_by_event_type()) == {"Soirée", "Collective"}
+
+    # Empty selection means no restriction on event type.
+    engine = StatisticsEngine(event_type_ids=[])
+    assert engine.nb_events() == 6


### PR DESCRIPTION
## Summary

Adds a second filter to the statistics page: a **"Types d'événement"** multiselect next to the existing activity-type dropdown. Selecting one or more event types restricts every statistic to events of those types. Leaving it empty keeps the previous "all event types" behaviour.

## Changes

- **`forms/stats.py`** — new `event_type_ids` `SelectMultipleField`, populated from `EventType.get_all_types()`.
- **`utils/stats.py`** — `StatisticsEngine` gains an `event_type_ids` attribute. `global_filters()` adds `Event.event_type_id.in_(...)` when non-empty, so all stat methods inherit the filter. The field is folded into `__str__`/`__eq__` so the per-engine `lru_cache` keys don't collide between selections.
- **`routes/root.py`** — the `statistics()` route forwards the selected event types into the engine.
- **`templates/stats/stats.html`** — renders the field as a Choices.js widget (same as the activity-type selector on the event form), with a handler that clears the placeholder once a type is selected.

## Tests

- Added `test_statistics_engine_only_party` covering single-type, multi-type (union), and empty (no restriction) cases.
- `uv run pytest tests/test_stats.py` → passes; manual route render verified.
- `ruff check` / `ruff format --check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
