### PR TITLE
Add break-word behaviour for event descriptions

### DIFF
--- a/collectives/static/css/components/collective-display.scss
+++ b/collectives/static/css/components/collective-display.scss
@@ -40,6 +40,7 @@
 
     &--description {
        padding-bottom: $padding-vertical-l;
+       overflow-wrap: break-word;
 
        table{
             border-collapse: collapse;


### PR DESCRIPTION
Long text is causing the event description element to overflow the viewport causing janky horizontal scroll. Adding `overflow-wrap: break-word` means long text items (e.g. long URLs) without spaces will wrap inside the container.