### PR TITLE
[FEATURE] Accessible and clearer event list filters

### DIFF
--- a/collectives/static/css/components/collectives-list.scss
+++ b/collectives/static/css/components/collectives-list.scss
@@ -1,7 +1,7 @@
 $collectives-list-row-height: 185px;
 $button-height:40px;
 %borders {
-    border: solid 1px $color-gray-light;
+    border: solid 1px $color-gray-border;
     border-radius: 100px;
 }
 
@@ -344,27 +344,60 @@ $button-height:40px;
     .toggle-button {
         @extend %borders;
         height: $button-height;
-        font-size: $button-height/2;
         line-height: $button-height;
         display: inline-block;
         padding: 0 10px;
         color: $color-gray-dark;
+        background: $color-white;
         cursor: pointer;
+        font-family: inherit;
         font-weight: normal;
         font-size: $font-size-s;
         text-transform: none;
+        white-space: nowrap;
         img {
             height: 1.2em;
             vertical-align: middle;
         }
+        // Etat actif signale par le fond et la graisse, pas par l'epaisseur du
+        // contour: un changement de border-width decalerait toute la barre.
         &.enabled {
             font-weight: 500;
-            border-width: 3px;
+            background: $color-blue-bg-light;
+            border-color: $color-blue-primary-dark;
         }
+        .pi {
+            font-size: $font-size-xs;
+            vertical-align: middle;
+        }
+    }
+
+    // Compteur des filtres actifs restes masques sous « Plus de filtres ».
+    .filter-badge {
+        display: inline-block;
+        min-width: 1.5em;
+        margin-left: 5px;
+        padding: 0 4px;
+        border-radius: 100px;
+        background: $color-blue-primary-dark;
+        color: $color-white;
+        font-weight: 500;
+        line-height: 1.5em;
+    }
+
+    // Le focus clavier doit rester visible sur tous les controles de la barre.
+    // Les selecteurs PrimeVue sont repris tels quels: leur thème pose un focus
+    // sans contour, avec une specificite superieure a `:focus-visible` seul.
+    :focus-visible,
+    .p-inputtext:enabled:focus-visible,
+    .p-multiselect:not(.p-disabled).p-focus {
+        outline: 3px solid $color-blue-primary-dark;
+        outline-offset: 2px;
     }
 
     .borders, input.date, .p-autocomplete-input{
         @extend %borders;
+        gap: 5px;
         height: $button-height;
         font-weight: normal;
         color: $color-gray-dark;
@@ -377,6 +410,15 @@ $button-height:40px;
         .p-datepicker input {
             border: none;
             max-width: 120px;
+        }
+        // L'input herite du contour porte par le label qui l'englobe.
+        > input {
+            flex-grow: 1;
+            min-width: 0;
+            height: 100%;
+            border: none;
+            background: transparent;
+            font-family: inherit;
         }
     }
 

--- a/collectives/static/css/utilities/display.scss
+++ b/collectives/static/css/utilities/display.scss
@@ -39,3 +39,16 @@
 .display-table-cell {
     display: table-cell;
 }
+
+/* Masque un texte à l'écran en le laissant lisible par les lecteurs d'écran. */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}

--- a/collectives/static/css/variables/colors.scss
+++ b/collectives/static/css/variables/colors.scss
@@ -83,6 +83,9 @@ $color-blue-bg-light: $solitude;
 $color-gray-dark: $woodsmoke;
 $color-gray-medium: $dove-gray;
 $color-gray-light: lighten($dove-gray, 40%);
+// Contour des champs et boutons: $color-gray-light (1.33:1 sur blanc) est sous le
+// seuil WCAG 1.4.11 de 3:1 exigé pour les composants d'interface. #767676 tient 4.5:1.
+$color-gray-border: #767676;
 $color-black: #000;
 $color-white: #fff;
 

--- a/collectives/static/js/event/eventlist-filters.component.js
+++ b/collectives/static/js/event/eventlist-filters.component.js
@@ -1,8 +1,9 @@
 import { searchLeaders } from "../api.js";
 
-const { ref, inject, reactive } = Vue
+const { ref, inject, reactive, computed } = Vue
 
-
+/** Un critère est actif s'il porte une valeur (liste non vide, texte, date, booléen vrai). */
+const isSet = (value) => (Array.isArray(value) ? value.length > 0 : Boolean(value))
 
 export default {
 
@@ -11,7 +12,6 @@ export default {
   },
 
   setup (props) {
-    const displayMoreFilters = ref(false)
     const config = inject('config')
 
     const leadersSearch = reactive({
@@ -36,10 +36,54 @@ export default {
       return `/static/caf/icon/${iconName}.svg`
     };
 
+    // Les filtres sont conservés en localStorage sans date d'expiration: un critère
+    // retiré côté serveur depuis la dernière visite y subsiste. Le rendu de son chip
+    // échoue alors, et c'est le filtre entier qui disparait de la barre.
+    const pruneUnknown = (selected, options) =>
+      (selected || []).filter(id => options.some(option => option.id === id))
+
+    props.filters.activities = pruneUnknown(props.filters.activities, config.activityList)
+    props.filters.eventTypes = pruneUnknown(props.filters.eventTypes, config.eventTypes)
+    props.filters.eventTags = pruneUnknown(props.filters.eventTags, config.eventTags)
+
+    /** Critères masqués tant que « Plus de filtres » n'est pas déplié. */
+    const advancedFilters = () => [
+      props.filters.eventTypes,
+      props.filters.eventTags,
+      props.filters.date,
+      props.filters.title,
+      props.filters.leader,
+      props.filters.displayCancelled,
+    ]
+
+    const advancedFilterCount = computed(() => advancedFilters().filter(isSet).length)
+    const activeFilterCount = computed(
+      () => advancedFilterCount.value + (isSet(props.filters.activities) ? 1 : 0)
+    )
+
+    // Les filtres sont restaurés du localStorage d'une visite à l'autre. Si l'un des
+    // critères avancés est actif, on déplie le panneau: sinon la liste s'affiche
+    // filtrée sans que rien à l'écran ne l'explique.
+    const displayMoreFilters = ref(advancedFilterCount.value > 0)
+
+    const resetFilters = () => Object.assign(props.filters, {
+      activities: [],
+      eventTypes: [],
+      eventTags: [],
+      date: null,
+      title: null,
+      leader: null,
+      displayCancelled: false,
+    })
+
     return {
       displayMoreFilters,
       filters: props.filters,
       config,
+      advancedFilterCount,
+      activeFilterCount,
+      resetFilters,
+      toggleMoreFilters: () => displayMoreFilters.value = !displayMoreFilters.value,
       toggleCancelled: () => props.filters.displayCancelled = !props.filters.displayCancelled,
       findInConfig: (list, activityId) => list.find(id =>  id.id === activityId),
       fetchLeaders,
@@ -49,7 +93,7 @@ export default {
     }
   },
   template: `
-  <div class="collectives-list-filters">
+  <search class="collectives-list-filters" role="search" aria-label="Filtrer les collectives">
     <p-multiselect 
       class="select-activity w-full sm:w-100>" 
       v-model="filters.activities" 
@@ -61,6 +105,7 @@ export default {
       :showToggleAll="false"
       scrollHeight="90vh"
       placeholder="Toutes activités"
+      ariaLabel="Filtrer par activité"
     >
       <template #option="slotProps">
           <div class="flex items-center">
@@ -79,13 +124,19 @@ export default {
       </template>
     </p-multiselect>
 
-    <div 
-      v-if="!displayMoreFilters"
+    <button
+      type="button"
       class="toggle-button collectives-list-filters-toggle-label button-primary"
-      @click="displayMoreFilters = true"
+      @click="toggleMoreFilters"
+      :aria-expanded="displayMoreFilters"
     >
-      + Plus de filtres
-    </div>
+      <span v-if="!displayMoreFilters">+ Plus de filtres</span>
+      <span v-else>&minus; Moins de filtres</span>
+      <span
+        v-if="!displayMoreFilters && advancedFilterCount > 0"
+        class="filter-badge"
+      >{{ advancedFilterCount }}<span class="visually-hidden"> filtre(s) masqué(s) actif(s)</span></span>
+    </button>
 
     <template v-if="displayMoreFilters">
 
@@ -100,6 +151,7 @@ export default {
         display="chip" 
         appendTo="self"
         :showToggleAll="false"
+        ariaLabel="Filtrer par type d'événement"
       >
         <template #option="slotProps">
           <div class="flex items-center">
@@ -129,6 +181,7 @@ export default {
         display="chip" 
         appendTo="self"
         :showToggleAll="false"
+        ariaLabel="Filtrer par label"
       >
         <template #option="slotProps">
           <div class="flex items-center">
@@ -148,8 +201,11 @@ export default {
       </p-multiselect>
 
       <div class="input date">
-        <label class="borders"> 📅 Depuis
+        <label class="borders" for="filter-date">
+          <i class="pi pi-calendar" aria-hidden="true"></i>
+          Depuis
           <p-datepicker 
+            inputId="filter-date"
             dateFormat="dd/mm/yy"
             v-model="filters.date"
             placeholder="Aujourd'hui"
@@ -157,24 +213,46 @@ export default {
         </label>
       </div>
 
-      <input class="borders" id="title" type="text" v-model="filters.title" placeholder="🔍 Titre">
+      <label class="borders" for="filter-title">
+        <i class="pi pi-search" aria-hidden="true"></i>
+        <span class="visually-hidden">Titre de la collective</span>
+        <input id="filter-title" type="text" v-model="filters.title" placeholder="Titre">
+      </label>
 
       <AutoComplete 
-        id="leader" 
+        inputId="filter-leader" 
         v-model="filters.leader" 
         :suggestions="leadersSearch.results" 
         :loading="leadersSearch.loading"
         @complete="fetchLeaders" 
-        placeholder="🔍 Encadrant"
+        placeholder="Encadrant"
+        ariaLabel="Rechercher un encadrant"
       />
 
-      <div id="cancelled" class="toggle-button font-size-s"  @click="toggleCancelled" :class="{ enabled: filters.displayCancelled }">
+      <button
+        type="button"
+        id="cancelled"
+        class="toggle-button font-size-s"
+        @click="toggleCancelled"
+        :class="{ enabled: filters.displayCancelled }"
+        :aria-pressed="filters.displayCancelled"
+      >
         Sorties annulées :
-        <span v-if="filters.displayCancelled" class="icon-button display-for-on">affichées <img src="/static/img/icon/ionicon/eye.svg" alt="&#128065"/></span>
-        <span v-if="!filters.displayCancelled" class="icon-button display-for-off">cachées <img src="/static/img/icon/ionicon/eye-off.svg"/></span>
-      </div>
+        <span v-if="filters.displayCancelled" class="icon-button display-for-on">affichées <img src="/static/img/icon/ionicon/eye.svg" alt=""/></span>
+        <span v-if="!filters.displayCancelled" class="icon-button display-for-off">cachées <img src="/static/img/icon/ionicon/eye-off.svg" alt=""/></span>
+      </button>
 
     </template>
-  </div>
+
+    <button
+      type="button"
+      v-if="activeFilterCount > 0"
+      class="toggle-button font-size-s reset-filters"
+      @click="resetFilters"
+    >
+      <i class="pi pi-times" aria-hidden="true"></i>
+      Tout effacer<span class="visually-hidden"> les filtres</span>
+    </button>
+  </search>
   `
 }


### PR DESCRIPTION
La barre de filtres de la page d'accueil ne pouvait pas être utilisée au clavier, n'exposait presque rien aux lecteurs d'écran, et pouvait filtrer la liste sans qu'aucun élément à l'écran ne l'indique. Cette PR ne touche que la barre de filtres (`eventlist-filters.component.js` et le SCSS associé) : aucun code Python n'est modifié.

### Après

![Barre de filtres après](https://raw.githubusercontent.com/florentdestremau/collectives/assets/filter-screenshots/doc/screenshots/filters-after.png)

### Avant

![Barre de filtres avant](https://raw.githubusercontent.com/florentdestremau/collectives/assets/filter-screenshots/doc/screenshots/filters-before.png)

## Accessibilité

Mesures relevées dans le navigateur, avant et après :

| Point | Avant | Après |
|---|---|---|
| Contraste du contour des champs (WCAG 1.4.11, seuil 3:1) | **1,33** ❌ | **4,54** ✅ |
| Contrôles atteignables au clavier | 6 sur 8 | **9 sur 9** ✅ |
| Focus clavier visible | absent sur Date et Encadrant | présent sur tous ✅ |
| Champs disposant d'un nom accessible | **0 sur 6** | **6 sur 6** ✅ |

Le point le plus lourd est le contraste : les contours à `#DFDFDF` sur fond blanc plafonnaient à 1,33:1 là où WCAG 1.4.11 demande 3:1 pour les composants d'interface. Les pilules étaient à peine perceptibles. Une variable `$color-gray-border` (`#767676`, 4,54:1) est introduite pour cet usage.

Le reste :

- les deux `<div @click>` (« Plus de filtres » et « Sorties annulées ») deviennent de vrais `<button>` portant `aria-expanded` / `aria-pressed` ; ils étaient inatteignables au clavier et invisibles pour un lecteur d'écran ;
- chaque filtre reçoit un nom accessible — aucun des six n'en avait, les placeholders seuls ne suffisent pas ;
- le focus clavier reste visible partout, y compris sur le sélecteur de date et l'autocomplétion PrimeVue, dont le thème le supprimait ;
- les emoji utilisés comme icônes (`🔍`, `📅`) sont remplacés par des icônes décoratives : un lecteur d'écran énonçait « loupe » avant le libellé du champ ;
- la barre est encapsulée dans un `<search>`, et les icônes décoratives reçoivent `alt=""`.

Un utilitaire `.visually-hidden` est ajouté à `utilities/display.scss` ; le projet n'en avait pas.

## Ergonomie

- **Le repli était sans retour** : une fois « + Plus de filtres » ouvert, plus aucun moyen de le refermer. Le bouton bascule maintenant vers « − Moins de filtres ».
- **Filtrage invisible** : les filtres sont restaurés depuis le `localStorage` d'une visite à l'autre, mais le panneau s'ouvrait toujours replié. On pouvait donc revenir sur le site avec un filtre actif masqué et ne pas comprendre pourquoi la liste était incomplète. Le panneau s'ouvre désormais si un critère masqué est actif, et un badge chiffré les signale lorsqu'il est replié.
- Ajout d'un bouton **« Tout effacer »**, visible dès qu'un filtre est actif.

## Correction d'un bug

Les filtres sont conservés en `localStorage` sans expiration. Si une activité, un type d'événement ou un label est retiré ou renommé côté serveur, l'identifiant obsolète y subsiste ; le rendu de son chip échouait, et **c'est le filtre Activités en entier qui disparaissait de la barre**, silencieusement et durablement pour le visiteur concerné. Les identifiants inconnus sont maintenant écartés au montage du composant. Rencontré pour de vrai en testant avec un identifiant périmé.

## Vérifications

- `uv run pytest --cov=collectives tests/` : 252 tests passés, couverture 75,07 % (inchangée)
- `uvx ruff format --check` et `uvx ruff check` : OK
- Parcours complet des filtres dans Chromium (sélection, saisie, bascule, réinitialisation) : aucune erreur console
- Rendu vérifié en 1280px et 390px de large

## Hors périmètre

La palette générale reste non conforme et mériterait une PR à part, à discuter avec le design : la couleur des liens est à 2,99:1 et les boutons primaires (`#00A5CC`) à 2,89:1, sous le seuil de 4,5:1. Les liens n'étant pas soulignés par défaut, rien ne les distingue du texte pour qui perçoit mal les couleurs.

Petite incohérence assumée : le champ « Encadrant » n'a pas d'icône loupe contrairement au champ « Titre », l'`AutoComplete` de PrimeVue générant sa propre structure d'input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
